### PR TITLE
Register block render callbacks and harden templates

### DIFF
--- a/blocks/about/block.json
+++ b/blocks/about/block.json
@@ -22,5 +22,6 @@
             "selector": "p"
         }
     },
-    "style": "file:./style.css"
+    "style": "file:./style.css",
+    "render": "file:./render.php"
 }

--- a/blocks/about/render.php
+++ b/blocks/about/render.php
@@ -14,15 +14,23 @@ $wrapper_attributes = get_block_wrapper_attributes(
         'id' => 'about', // Keep the ID for anchor links
     ]
 );
+
+$headline = isset( $attributes['headline'] ) ? $attributes['headline'] : '';
+$text     = isset( $attributes['text'] ) ? $attributes['text'] : '';
 ?>
 
 <section <?php echo $wrapper_attributes; ?>>
     <div class="container">
-        <h2 class="section-title">
-            <?php echo esc_html( $attributes['headline'] ); ?>
-        </h2>
-        <p>
-            <?php echo wp_kses_post( $attributes['text'] ); ?>
-        </p>
+        <?php if ( ! empty( $headline ) ) : ?>
+            <h2 class="section-title">
+                <?php echo esc_html( $headline ); ?>
+            </h2>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $text ) ) : ?>
+            <p>
+                <?php echo wp_kses_post( $text ); ?>
+            </p>
+        <?php endif; ?>
     </div>
 </section>

--- a/blocks/cta/block.json
+++ b/blocks/cta/block.json
@@ -25,5 +25,6 @@
             "default": "mailto:contact@mccullough.digital"
         }
     },
-    "style": "file:./style.css"
+    "style": "file:./style.css",
+    "render": "file:./render.php"
 }

--- a/blocks/cta/render.php
+++ b/blocks/cta/render.php
@@ -15,15 +15,24 @@ $wrapper_attributes = get_block_wrapper_attributes(
         'class' => 'cta-section',
     ]
 );
+
+$headline    = isset( $attributes['headline'] ) ? $attributes['headline'] : '';
+$button_text = isset( $attributes['buttonText'] ) ? $attributes['buttonText'] : '';
+$button_link = isset( $attributes['buttonLink'] ) ? $attributes['buttonLink'] : '';
 ?>
 
 <section <?php echo $wrapper_attributes; ?>>
     <div class="container">
-        <h2 class="section-title">
-            <?php echo esc_html( $attributes['headline'] ); ?>
-        </h2>
-        <a href="<?php echo esc_url( $attributes['buttonLink'] ); ?>" class="cta-button">
-            <span class="btn-text"><?php echo esc_html( $attributes['buttonText'] ); ?></span>
-        </a>
+        <?php if ( ! empty( $headline ) ) : ?>
+            <h2 class="section-title">
+                <?php echo esc_html( $headline ); ?>
+            </h2>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $button_text ) ) : ?>
+            <a href="<?php echo esc_url( $button_link ); ?>" class="cta-button">
+                <span class="btn-text"><?php echo esc_html( $button_text ); ?></span>
+            </a>
+        <?php endif; ?>
     </div>
 </section>

--- a/blocks/hero/block.json
+++ b/blocks/hero/block.json
@@ -31,5 +31,6 @@
         }
     },
     "editorScript": "file:./script.js",
-    "style": "file:./style.css"
+    "style": "file:./style.css",
+    "render": "file:./render.php"
 }

--- a/blocks/hero/render.php
+++ b/blocks/hero/render.php
@@ -14,20 +14,31 @@ $wrapper_attributes = get_block_wrapper_attributes(
         'class' => 'hero',
     ]
 );
+
+$headline    = isset( $attributes['headline'] ) ? $attributes['headline'] : '';
+$subheading  = isset( $attributes['subheading'] ) ? $attributes['subheading'] : '';
+$button_text = isset( $attributes['buttonText'] ) ? $attributes['buttonText'] : '';
+$button_link = isset( $attributes['buttonLink'] ) ? $attributes['buttonLink'] : '';
 ?>
 
 <section <?php echo $wrapper_attributes; ?>>
     <canvas id="particle-canvas"></canvas>
     <div class="hero-content">
-        <h1 id="interactive-headline" class="wp-block-heading">
-            <?php echo wp_kses_post( $attributes['headline'] ); ?>
-        </h1>
-        <p>
-            <?php echo wp_kses_post( $attributes['subheading'] ); ?>
-        </p>
-        <?php if ( ! empty( $attributes['buttonText'] ) ) : ?>
-            <a href="<?php echo esc_url( $attributes['buttonLink'] ); ?>" class="cta-button">
-                <span class="btn-text"><?php echo esc_html( $attributes['buttonText'] ); ?></span>
+        <?php if ( ! empty( $headline ) ) : ?>
+            <h1 id="interactive-headline" class="wp-block-heading">
+                <?php echo wp_kses_post( $headline ); ?>
+            </h1>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $subheading ) ) : ?>
+            <p>
+                <?php echo wp_kses_post( $subheading ); ?>
+            </p>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $button_text ) ) : ?>
+            <a href="<?php echo esc_url( $button_link ); ?>" class="cta-button">
+                <span class="btn-text"><?php echo esc_html( $button_text ); ?></span>
             </a>
         <?php endif; ?>
     </div>

--- a/blocks/service-card/block.json
+++ b/blocks/service-card/block.json
@@ -35,5 +35,6 @@
             "type": "string",
             "default": "#"
         }
-    }
+    },
+    "render": "file:./render.php"
 }

--- a/blocks/service-card/render.php
+++ b/blocks/service-card/render.php
@@ -14,23 +14,39 @@ $wrapper_attributes = get_block_wrapper_attributes(
         'class' => 'service-card',
     ]
 );
+
+$icon      = isset( $attributes['icon'] ) ? $attributes['icon'] : '';
+$title     = isset( $attributes['title'] ) ? $attributes['title'] : '';
+$text      = isset( $attributes['text'] ) ? $attributes['text'] : '';
+$link_text = isset( $attributes['linkText'] ) ? $attributes['linkText'] : '';
+$link_url  = isset( $attributes['linkUrl'] ) ? $attributes['linkUrl'] : '';
 ?>
 
 <div <?php echo $wrapper_attributes; ?>>
    <div class="service-card-content">
         <div>
-            <div class="icon">
-                <?php echo $attributes['icon']; // Note: This will be raw SVG content. It's ok since it's from an admin. ?>
-            </div>
-            <h3>
-                <?php echo esc_html( $attributes['title'] ); ?>
-            </h3>
-            <p>
-                <?php echo esc_html( $attributes['text'] ); ?>
-            </p>
+            <?php if ( ! empty( $icon ) ) : ?>
+                <div class="icon">
+                    <?php echo $icon; // Note: This will be raw SVG content from trusted admin input. ?>
+                </div>
+            <?php endif; ?>
+
+            <?php if ( ! empty( $title ) ) : ?>
+                <h3>
+                    <?php echo esc_html( $title ); ?>
+                </h3>
+            <?php endif; ?>
+
+            <?php if ( ! empty( $text ) ) : ?>
+                <p>
+                    <?php echo esc_html( $text ); ?>
+                </p>
+            <?php endif; ?>
         </div>
-        <a href="<?php echo esc_url( $attributes['linkUrl'] ); ?>" class="learn-more">
-            <?php echo esc_html( $attributes['linkText'] ); ?>
-        </a>
+        <?php if ( ! empty( $link_text ) ) : ?>
+            <a href="<?php echo esc_url( $link_url ); ?>" class="learn-more">
+                <?php echo esc_html( $link_text ); ?>
+            </a>
+        <?php endif; ?>
     </div>
 </div>

--- a/blocks/services/block.json
+++ b/blocks/services/block.json
@@ -17,5 +17,6 @@
             "selector": "h2"
         }
     },
-    "style": "file:./style.css"
+    "style": "file:./style.css",
+    "render": "file:./render.php"
 }

--- a/blocks/services/render.php
+++ b/blocks/services/render.php
@@ -15,6 +15,8 @@ $wrapper_attributes = get_block_wrapper_attributes(
     ]
 );
 
+$headline = isset( $attributes['headline'] ) ? $attributes['headline'] : '';
+
 // The InnerBlocks template defines the allowed blocks and their default state.
 $allowed_blocks = [ 'mccullough-digital/service-card' ];
 $template = [
@@ -27,9 +29,11 @@ $template = [
 
 <section <?php echo $wrapper_attributes; ?>>
     <div class="container">
-        <h2 class="section-title">
-            <?php echo wp_kses_post( $attributes['headline'] ); ?>
-        </h2>
+        <?php if ( ! empty( $headline ) ) : ?>
+            <h2 class="section-title">
+                <?php echo wp_kses_post( $headline ); ?>
+            </h2>
+        <?php endif; ?>
         <div class="services-grid">
             <InnerBlocks allowedBlocks="<?php echo esc_attr( wp_json_encode( $allowed_blocks ) ); ?>" template="<?php echo esc_attr( wp_json_encode( $template ) ); ?>" />
         </div>


### PR DESCRIPTION
## Summary
- reference each block's PHP renderer from its `block.json` so `register_block_type()` autoloads the callback
- guard dynamic template output against missing attributes while preserving intended markup for hero, services, service-card, about, and CTA sections
- reviewed `templates/front-page.html` to confirm the template continues to include the dynamic sections after the cache clear step

## Testing
- not run (non-WordPress environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7654533288324b0996bc30eae386e