### PR TITLE
Add InnerBlocks configuration to services block

### DIFF
--- a/blocks/services/block.json
+++ b/blocks/services/block.json
@@ -10,6 +10,16 @@
         "html": false,
         "anchor": true
     },
+    "innerBlocks": {
+        "allowedBlocks": [
+            "mccullough-digital/service-card"
+        ],
+        "template": [
+            ["mccullough-digital/service-card"],
+            ["mccullough-digital/service-card"],
+            ["mccullough-digital/service-card"]
+        ]
+    },
     "attributes": {
         "headline": {
             "type": "string",

--- a/blocks/services/editor.js
+++ b/blocks/services/editor.js
@@ -1,8 +1,21 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { useBlockProps, RichText } from '@wordpress/block-editor';
+import { useBlockProps, RichText, InnerBlocks } from '@wordpress/block-editor';
 
 import metadata from './block.json';
+
+const {
+    innerBlocks: {
+        allowedBlocks: allowedServiceBlocks = [
+            'mccullough-digital/service-card',
+        ],
+        template: servicesTemplate = [
+            ['mccullough-digital/service-card'],
+            ['mccullough-digital/service-card'],
+            ['mccullough-digital/service-card'],
+        ],
+    } = {},
+} = metadata;
 
 registerBlockType(metadata.name, {
     ...metadata,
@@ -11,12 +24,16 @@ registerBlockType(metadata.name, {
         const blockProps = useBlockProps();
 
         return (
-            <section { ...blockProps }>
+            <section {...blockProps}>
                 <RichText
                     tagName="h2"
                     value={ headline }
                     onChange={ (value) => setAttributes({ headline: value }) }
                     placeholder={ __('Add services headline…', 'mccullough-digital') }
+                />
+                <InnerBlocks
+                    allowedBlocks={ allowedServiceBlocks }
+                    template={ servicesTemplate }
                 />
             </section>
         );

--- a/blocks/services/render.php
+++ b/blocks/services/render.php
@@ -2,26 +2,35 @@
 /**
  * Services Block Template.
  *
- * @param   array $attributes - The block attributes.
- * @param   string $content - The block inner content (from InnerBlocks).
- * @param   WP_Block $block - The block instance.
+ * @param   array    $attributes - The block attributes.
+ * @param   string   $content    - The block inner content (from InnerBlocks).
+ * @param   WP_Block $block      - The block instance.
  *
  * @package McCullough_Digital
  */
 
-$wrapper_attributes = get_block_wrapper_attributes(
+$metadata = wp_json_file_decode(
+    __DIR__ . '/block.json',
     [
-        'id' => 'services', // Keep the ID for anchor links
+        'associative' => true,
     ]
 );
 
-// The InnerBlocks template defines the allowed blocks and their default state.
-$allowed_blocks = [ 'mccullough-digital/service-card' ];
-$template = [
+$inner_blocks    = $metadata['innerBlocks'] ?? [];
+$allowed_blocks  = $inner_blocks['allowedBlocks'] ?? [ 'mccullough-digital/service-card' ];
+$template        = $inner_blocks['template'] ?? [
     [ 'mccullough-digital/service-card' ],
     [ 'mccullough-digital/service-card' ],
     [ 'mccullough-digital/service-card' ],
 ];
+
+// The $allowed_blocks and $template variables mirror the editor configuration for future use.
+
+$wrapper_attributes = get_block_wrapper_attributes(
+    [
+        'id' => 'services', // Keep the ID for anchor links.
+    ]
+);
 
 ?>
 


### PR DESCRIPTION
## Summary
- add InnerBlocks support to the services editor so default service cards appear while constraining the allowed block type
- store the allowed blocks and template defaults in block metadata and load them in PHP for parity between editor and render logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d78105f90883248fc634f8a2f9f622