### PR TITLE
Allow inline formatting for CTA and About headlines

### DIFF
--- a/blocks/about/render.php
+++ b/blocks/about/render.php
@@ -19,7 +19,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 <section <?php echo $wrapper_attributes; ?>>
     <div class="container">
         <h2 class="section-title">
-            <?php echo esc_html( $attributes['headline'] ); ?>
+            <?php echo wp_kses_post( $attributes['headline'] ); ?>
         </h2>
         <p>
             <?php echo wp_kses_post( $attributes['text'] ); ?>

--- a/blocks/cta/render.php
+++ b/blocks/cta/render.php
@@ -20,7 +20,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 <section <?php echo $wrapper_attributes; ?>>
     <div class="container">
         <h2 class="section-title">
-            <?php echo esc_html( $attributes['headline'] ); ?>
+            <?php echo wp_kses_post( $attributes['headline'] ); ?>
         </h2>
         <a href="<?php echo esc_url( $attributes['buttonLink'] ); ?>" class="cta-button">
             <span class="btn-text"><?php echo esc_html( $attributes['buttonText'] ); ?></span>


### PR DESCRIPTION
## Summary
- allow inline formatting tags to render in the About block headline
- allow inline formatting tags to render in the CTA block headline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d781126590832482844edec79e18a1