### PR TITLE
Handle social link URLs without hosts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -126,7 +126,13 @@ function mcd_get_social_link_svg( $url ) {
         'github.com'   => 'github',
     ];
 
-    $domain = str_ireplace( 'www.', '', parse_url( $url, PHP_URL_HOST ) );
+    $host = parse_url( $url, PHP_URL_HOST );
+
+    if ( ! $host ) {
+        return '';
+    }
+
+    $domain = preg_replace( '/^www\./i', '', $host );
 
     if ( isset( $social_icons[ $domain ] ) ) {
         $icon_name = $social_icons[ $domain ];


### PR DESCRIPTION
## Summary
- guard against hostless social menu URLs by returning early before icon lookup
- normalize parsed hosts before matching against known social icon map

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d78116e14c83249373723382f98d64