### PR TITLE
Respect custom anchors in section blocks

### DIFF
--- a/blocks/about/render.php
+++ b/blocks/about/render.php
@@ -9,9 +9,10 @@
  * @package McCullough_Digital
  */
 
+$section_id         = ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'about';
 $wrapper_attributes = get_block_wrapper_attributes(
     [
-        'id' => 'about', // Keep the ID for anchor links
+        'id' => $section_id,
     ]
 );
 ?>

--- a/blocks/cta/render.php
+++ b/blocks/cta/render.php
@@ -9,9 +9,10 @@
  * @package McCullough_Digital
  */
 
+$section_id         = ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'contact';
 $wrapper_attributes = get_block_wrapper_attributes(
     [
-        'id'    => 'contact', // Keep the ID for anchor links
+        'id'    => $section_id,
         'class' => 'cta-section',
     ]
 );

--- a/blocks/services/render.php
+++ b/blocks/services/render.php
@@ -9,9 +9,10 @@
  * @package McCullough_Digital
  */
 
+$section_id         = ! empty( $attributes['anchor'] ) ? $attributes['anchor'] : 'services';
 $wrapper_attributes = get_block_wrapper_attributes(
     [
-        'id' => 'services', // Keep the ID for anchor links
+        'id' => $section_id,
     ]
 );
 


### PR DESCRIPTION
## Summary
- ensure the About, Services, and CTA block renderers prioritize user-defined anchors while preserving legacy defaults
- keep the CTA block's custom wrapper class while updating its ID logic

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d781b5739c832483ebe81daa684a32