### PR TITLE
Enable full alignment options for homepage sections

### DIFF
--- a/blocks/about/block.json
+++ b/blocks/about/block.json
@@ -12,7 +12,11 @@
     "apiVersion": 2,
     "supports": {
         "html": false,
-        "anchor": true
+        "anchor": true,
+        "align": [
+            "wide",
+            "full"
+        ]
     },
     "attributes": {
         "headline": {

--- a/blocks/cta/block.json
+++ b/blocks/cta/block.json
@@ -12,7 +12,11 @@
     "apiVersion": 2,
     "supports": {
         "html": false,
-        "anchor": true
+        "anchor": true,
+        "align": [
+            "wide",
+            "full"
+        ]
     },
     "attributes": {
         "headline": {

--- a/blocks/hero/block.json
+++ b/blocks/hero/block.json
@@ -12,7 +12,11 @@
     "apiVersion": 2,
     "supports": {
         "html": false,
-        "anchor": true
+        "anchor": true,
+        "align": [
+            "wide",
+            "full"
+        ]
     },
     "attributes": {
         "headline": {

--- a/blocks/services/block.json
+++ b/blocks/services/block.json
@@ -12,7 +12,11 @@
     "apiVersion": 2,
     "supports": {
         "html": false,
-        "anchor": true
+        "anchor": true,
+        "align": [
+            "wide",
+            "full"
+        ]
     },
     "innerBlocks": {
         "allowedBlocks": [

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -1,18 +1,18 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","className":"site-content","layout":{"type":"constrained"}} -->
-<main class="wp-block-group site-content">
-  <!-- wp:mccullough-digital/hero {"headline":"Bringing Your Digital Vision to Life.","subheading":"We build beautiful, high-performance web experiences and creative marketing strategies that connect with your audience. Ready to create something amazing?","buttonText":"Start a Project","buttonLink":"#contact"} /-->
+<!-- wp:group {"tagName":"main","align":"full","className":"site-content","layout":{"type":"constrained"}} -->
+<main class="wp-block-group site-content alignfull">
+  <!-- wp:mccullough-digital/hero {"align":"full","headline":"Bringing Your Digital Vision to Life.","subheading":"We build beautiful, high-performance web experiences and creative marketing strategies that connect with your audience. Ready to create something amazing?","buttonText":"Start a Project","buttonLink":"#contact"} /-->
 
-  <!-- wp:mccullough-digital/services {"headline":"What We Do"} -->
+  <!-- wp:mccullough-digital/services {"align":"full","headline":"What We Do"} -->
   <!-- wp:mccullough-digital/service-card {"icon":"<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect x=\"2\" y=\"3\" width=\"20\" height=\"14\" rx=\"2\" ry=\"2\"></rect><line x1=\"8\" y1=\"21\" x2=\"16\" y2=\"21\"></line><line x1=\"12\" y1=\"17\" x2=\"12\" y2=\"21\"></line></svg>","title":"Complete Web Solutions","text":"We design, build, and host SEO-optimized websites. Every project includes analytics integration and ongoing monitoring to ensure your success.","linkText":"Explore Our Process →","linkUrl":"#"} /-->
   <!-- wp:mccullough-digital/service-card {"icon":"<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><line x1=\"12\" y1=\"1\" x2=\"12\" y2=\"23\"></line><path d=\"M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6\"></path></svg>","title":"Targeted Digital Advertising","text":"We manage your advertising campaigns across platforms like Google, Meta, and Nextdoor to reach your ideal customers and maximize your ROI.","linkText":"Discover Ad Management →","linkUrl":"#"} /-->
   <!-- wp:mccullough-digital/service-card {"icon":"<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M20.42 4.58a5.4 5.4 0 0 0-7.65 0l-.71.71a5.4 5.4 0 0 0 0 7.65l.71.71a5.4 5.4 0 0 0 7.65 0l4.24-4.24a5.4 5.4 0 0 0 0-7.65l-4.24-4.24z\"></path><path d=\"M10.1 19.24a5.4 5.4 0 0 0 7.65 0l.71-.71a5.4 5.4 0 0 0 0-7.65l-.71-.71a5.4 5.4 0 0 0-7.65 0l-1.42 1.42\"></path></svg>","title":"Integrated Social Media","text":"From profile setup to full-service management, we handle your social media presence, integrating it all so you can focus on your business.","linkText":"See Management Plans →","linkUrl":"#"} /-->
   <!-- /wp:mccullough-digital/services -->
 
-  <!-- wp:mccullough-digital/about {"headline":"About Us","text":"McCullough Digital is a small team of developers, designers, and strategists passionate about building beautiful things for the web. We thrive on collaboration and exist to create digital tools that help our clients succeed. We believe in clean code, thoughtful design, and a relentless pursuit of quality."} /-->
+  <!-- wp:mccullough-digital/about {"align":"full","headline":"About Us","text":"McCullough Digital is a small team of developers, designers, and strategists passionate about building beautiful things for the web. We thrive on collaboration and exist to create digital tools that help our clients succeed. We believe in clean code, thoughtful design, and a relentless pursuit of quality."} /-->
 
-  <!-- wp:mccullough-digital/cta {"headline":"Ready to Create?","buttonText":"Let's Talk","buttonLink":"mailto:contact@mccullough.digital"} /-->
+  <!-- wp:mccullough-digital/cta {"align":"full","headline":"Ready to Create?","buttonText":"Let's Talk","buttonLink":"mailto:contact@mccullough.digital"} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## Summary
- allow the hero, services, about, and CTA custom blocks to opt into wide/full alignment support
- default the front page template to render those sections with alignfull so they match the standalone layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80fc1d2a08324ad0f8b2d31f40d75