### PR TITLE
Align front page layout with standard templates

### DIFF
--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -1,8 +1,12 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","align":"full","className":"site-content","layout":{"type":"constrained"}} -->
-<main class="wp-block-group site-content alignfull">
-  <!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+<!-- wp:group {"tagName":"main","className":"site-content","layout":{"type":"constrained"}} -->
+<main class="wp-block-group site-content">
+  <!-- wp:group {"className":"container","layout":{"type":"constrained"}} -->
+  <div class="wp-block-group container">
+    <!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+  </div>
+  <!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## Summary
- wrap the front-page template content in the same site-content and container groups used on other templates
- ensure the shared header and footer template parts render consistently on the home page

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d85f5d8f5c83248be1a9a06c5d32a1