### PR TITLE
Fix hero headline word wrapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository contains the McCullough Digital block theme. The notes below sum
 ## Bug Fix & Improvement Highlights
 - **Latest (2025-09-30):**
     - Kept CTA button text readable by delaying the hover color swap until the gradient animation finishes and added a neon focus outline so keyboard users get the same visual feedback.
+    - Reworked the hero headline glitch markup so words wrap naturally while preserving the hover distortion and reduced-motion fallbacks.
 - **Latest (2025-09-29):**
     - Enabled padding, margin, color, and typography design tools across every custom block, added missing text domains, and unhid the service card block in the inserter so authors can freely compose sections from the editor.
     - Added reusable surface color tokens, spacing presets, and a defined wide content width to `theme.json`, updated both front-end and editor styles to consume the new palette, and wired up wide/full container helpers for accurate previews.

--- a/blocks/hero/style.css
+++ b/blocks/hero/style.css
@@ -39,16 +39,24 @@
     display: inline-block;
 }
 
+.wp-block-mccullough-digital-hero .hero__headline-text--visual {
+    white-space: normal;
+}
+
+.wp-block-mccullough-digital-hero .hero__headline-word {
+    display: inline-flex;
+    gap: 0;
+}
+
 /* --- Interactive Hero H1 Letters --- */
-.wp-block-mccullough-digital-hero .hero__headline-text--visual span {
+.wp-block-mccullough-digital-hero .hero__headline-letter {
     display: inline-block;
     position: relative;
     cursor: default;
-    white-space: pre;
 }
 
-.wp-block-mccullough-digital-hero .hero__headline-text--visual span:hover::before,
-.wp-block-mccullough-digital-hero .hero__headline-text--visual span:hover::after {
+.wp-block-mccullough-digital-hero .hero__headline-letter:hover::before,
+.wp-block-mccullough-digital-hero .hero__headline-letter:hover::after {
     content: attr(data-char);
     position: absolute;
     top: 0;
@@ -56,13 +64,13 @@
     animation: glitch 0.35s infinite;
 }
 
-.wp-block-mccullough-digital-hero .hero__headline-text--visual span:hover::before {
+.wp-block-mccullough-digital-hero .hero__headline-letter:hover::before {
     color: var(--neon-cyan);
     z-index: -1;
     animation-direction: reverse;
 }
 
-.wp-block-mccullough-digital-hero .hero__headline-text--visual span:hover::after {
+.wp-block-mccullough-digital-hero .hero__headline-letter:hover::after {
     color: var(--neon-magenta);
     z-index: -2;
 }
@@ -72,8 +80,8 @@
     display: none;
 }
 
-.wp-block-mccullough-digital-hero.is-reduced-motion .hero__headline-text--visual span:hover::before,
-.wp-block-mccullough-digital-hero.is-reduced-motion .hero__headline-text--visual span:hover::after {
+.wp-block-mccullough-digital-hero.is-reduced-motion .hero__headline-letter:hover::before,
+.wp-block-mccullough-digital-hero.is-reduced-motion .hero__headline-letter:hover::after {
     animation: none;
     content: none;
 }

--- a/blocks/hero/view.js
+++ b/blocks/hero/view.js
@@ -96,22 +96,47 @@
                 }
 
                 const fragment = document.createDocumentFragment();
+                let currentWord = null;
 
-                for (const char of text) {
+                const flushWord = () => {
+                    if (currentWord && currentWord.childNodes.length) {
+                        fragment.appendChild(currentWord);
+                    }
+
+                    currentWord = null;
+                };
+
+                const normalizedText = text.replace(/\r\n/g, '\n');
+
+                for (const char of normalizedText) {
                     if (char === '\n' || char === '\r') {
+                        flushWord();
                         fragment.appendChild(document.createElement('br'));
                         continue;
                     }
 
-                    const span = document.createElement('span');
-                    const outputChar = char === ' ' ? '\u00A0' : char;
+                    if (char.trim() === '') {
+                        flushWord();
+                        fragment.appendChild(document.createTextNode(char));
+                        continue;
+                    }
 
-                    span.dataset.char = outputChar;
-                    span.textContent = outputChar;
-                    span.setAttribute('aria-hidden', 'true');
+                    if (!currentWord) {
+                        currentWord = document.createElement('span');
+                        currentWord.classList.add('hero__headline-word');
+                    }
 
-                    fragment.appendChild(span);
+                    const letter = document.createElement('span');
+
+                    letter.classList.add('hero__headline-letter');
+                    letter.dataset.char = char;
+                    letter.textContent = char;
+                    letter.setAttribute('aria-hidden', 'true');
+
+                    currentWord.appendChild(letter);
                 }
+
+                flushWord();
 
                 if (node.parentNode) {
                     node.parentNode.replaceChild(fragment, node);

--- a/bug-report.md
+++ b/bug-report.md
@@ -10,6 +10,11 @@ This report now tracks the 2025-09-27 through 2025-09-30 sweeps, covering thirty
    *Issue:* The hero and post card CTA buttons turned their text dark as soon as hover started, but the gradient fill animation lagged behind, so the copy became unreadable on the dark background and there was no visible keyboard focus cue.
    *Resolution:* Delayed the text color swap until the gradient completes, extended the gradient layer so it matches the pill radius, and added a high-contrast focus outline so both mouse and keyboard interactions remain accessible.
 
+2. **Hero Headline Word Breaks**
+   *Files:* `blocks/hero/view.js`, `blocks/hero/style.css`
+   *Issue:* The interactive glitch animation replaced spaces with non-breaking spans, so long headlines couldn't wrap between words and would overflow at smaller viewports.
+   *Resolution:* Rebuilt the letter span logic to group characters per word and emit real whitespace/text nodes, then updated the hover selectors to target the new markup so the glitch effect and reduced-motion fallbacks continue to function.
+
 ### 2025-09-27 Sweep
 1. **Placeholder Links on Homepage**
    *Files:* `patterns/home-landing.php`

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.5 - 2025-09-30 =
+* **Hero Headline Animation:** Wrapped glitch letters per word so spaces render as real whitespace, restoring natural line breaks while keeping the hover distortion effect responsive.
+
 = 1.2.4 - 2025-09-30 =
 * **Hero CTA Accessibility:** Delayed the hover text color swap until the gradient fill completes so the "Start a Project" button stays legible while animating and added an explicit focus outline for keyboard users.
 

--- a/standalone.html
+++ b/standalone.html
@@ -268,15 +268,24 @@
             display: inline-block;
         }
 
+        .hero__headline-text--visual {
+            white-space: normal;
+        }
+
+        .hero__headline-word {
+            display: inline-flex;
+            gap: 0;
+        }
+
         /* --- Interactive Hero H1 Letters --- */
-        .hero__headline-text--visual span {
+        .hero__headline-letter {
             display: inline-block;
             position: relative;
             cursor: default;
         }
 
-        .hero__headline-text--visual span:hover::before,
-        .hero__headline-text--visual span:hover::after {
+        .hero__headline-letter:hover::before,
+        .hero__headline-letter:hover::after {
             content: attr(data-char);
             position: absolute;
             top: 0;
@@ -284,13 +293,13 @@
             animation: glitch 0.35s infinite;
         }
 
-        .hero__headline-text--visual span:hover::before {
+        .hero__headline-letter:hover::before {
             color: var(--neon-cyan);
             z-index: -1;
             animation-direction: reverse;
         }
 
-        .hero__headline-text--visual span:hover::after {
+        .hero__headline-letter:hover::after {
             color: var(--neon-magenta);
             z-index: -2;
         }
@@ -299,8 +308,8 @@
             display: none;
         }
 
-        .wp-block-mccullough-digital-hero.is-reduced-motion .hero__headline-text--visual span:hover::before,
-        .wp-block-mccullough-digital-hero.is-reduced-motion .hero__headline-text--visual span:hover::after {
+        .wp-block-mccullough-digital-hero.is-reduced-motion .hero__headline-letter:hover::before,
+        .wp-block-mccullough-digital-hero.is-reduced-motion .hero__headline-letter:hover::after {
             animation: none;
             content: none;
         }

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.4
+Version:       1.2.5
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital


### PR DESCRIPTION
## Summary
- rebuild the hero headline span logic so it groups letters by word and restores real whitespace while keeping the glitch hover accessible
- retarget hero block styles (and the standalone preview) to the new `.hero__headline-letter` structure and maintain responsive centering
- document the change by bumping the theme version to 1.2.5 and recording the fix in the sweep logs

## Testing
- npm run build
- Manual responsive check of the standalone hero preview

------
https://chatgpt.com/codex/tasks/task_e_68d8c3eb2f30832496fe1cb21e7effaa