### PR TITLE
Enable global spacing controls for theme blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-03):**
+    - Exposed global padding, margin, and block gap controls with unit selection in `theme.json` so Gutenberg surfaces the Dimen
+      sions panel for custom and core blocks that opt into spacing support.
 - **Latest (2025-10-02):**
     - Restored persistence for all InnerBlocks-based custom blocks by saving their nested content so Site Editor changes to templates, template parts, and marketing sections stick after reload.
 - **Latest (2025-10-01):**

--- a/bug-report.md
+++ b/bug-report.md
@@ -1,8 +1,16 @@
-# Bug Fix Report — 2025-10-02
+# Bug Fix Report — 2025-10-03
 
-This report now tracks the 2025-09-27 through 2025-10-02 sweeps, covering thirty-three production-impacting fixes and one code quality improvement in the McCullough Digital theme. Each item below lists the affected files, the observed problem, and the implemented remedy.
+This report now tracks the 2025-09-27 through 2025-10-03 sweeps, covering the growing set of production-impacting fixes and continuous improvements in the McCullough Digital theme. Each item below lists the affected files, the observed problem, and the implemented remedy.
 
 ## Fixed Bugs
+
+### 2025-10-03 Sweep
+1. **Missing Dimensions Controls**
+   *Files:* `theme.json`
+   *Issue:* The theme's spacing presets existed, but global padding, margin, block gap, and unit flags were absent, so Gutenber
+   g hid the Dimensions panel for custom sections and core blocks opting into spacing support.
+   *Resolution:* Enabled the spacing feature flags and unit list in `settings.spacing` so the editor exposes padding, margin, a
+   nd block gap controls backed by the defined presets.
 
 ### 2025-10-02 Sweep
 1. **Template Edits Lost After Saving**

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,10 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.8 - 2025-10-03 =
+* **Editor Controls:** Enabled global spacing support flags and unit options in `theme.json` so the Dimensions panel exposes pa
+dding, margin, and block gap controls across custom marketing sections and core blocks using spacing presets.
+
 = 1.2.7 - 2025-10-02 =
 * **Editor Persistence:** Updated all InnerBlocks-based custom blocks to save their nested content so edits to hero, CTA, about, services, and service card layouts now persist when templates or template parts are customized in the site editor.
 

--- a/theme.json
+++ b/theme.json
@@ -46,6 +46,15 @@
       ]
     },
     "spacing": {
+      "padding": true,
+      "margin": true,
+      "blockGap": true,
+      "units": [
+        "px",
+        "rem",
+        "em",
+        "%"
+      ],
       "spacingSizes": [
         {
           "slug": "10",


### PR DESCRIPTION
## Summary
- expose padding, margin, and block gap support flags plus spacing units in `theme.json`
- document the new spacing controls in `AGENTS.md`, `bug-report.md`, and the changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8d45536408324854367d8c681709a