### PR TITLE
Restore navigation hover animation and CTA alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-04):**
+    - Restored the neon navigation hover wobble with a reversed gradient sweep, re-centered the CTA layout, hid the standby gradient pill layer, and removed unintended header/section borders that introduced bright divider lines.
 - **Latest (2025-10-03):**
     - Exposed global padding, margin, and block gap controls with unit selection in `theme.json` so Gutenberg surfaces the Dimen
       sions panel for custom and core blocks that opt into spacing support.

--- a/blocks/cta/style.css
+++ b/blocks/cta/style.css
@@ -10,9 +10,25 @@
     margin-bottom: 30px;
 }
 
+.wp-block-mccullough-digital-cta .container,
+.wp-block-mccullough-digital-cta .wp-block-mccullough-digital-cta__inner,
+.wp-block-mccullough-digital-cta.cta-section .container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    padding: clamp(60px, 12vw, 140px) 0;
+}
+
+.wp-block-mccullough-digital-cta .section-title {
+    margin-bottom: 0;
+}
+
 .wp-block-mccullough-digital-cta .wp-block-buttons {
     justify-content: center;
     gap: 0;
+    width: 100%;
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button {

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,22 @@ This report now tracks the 2025-09-27 through 2025-10-03 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-04 Sweep
+1. **Navigation Hover Animation Regression**
+   *Files:* `style.css`
+   *Issue:* The primary navigation lost its intended hover treatment—the links no longer pulsed or wobbled, and the gradient fill swept in the same blue-to-pink direction as the header instead of the requested reverse.
+   *Resolution:* Restored the wobble and pulse animations, swapped the gradient to sweep pink-to-blue, and added a reduced-motion fallback so the effect respects accessibility preferences.
+
+2. **CTA Layout Drift & Double-Pill Button**
+   *Files:* `blocks/cta/style.css`, `style.css`
+   *Issue:* The hero and CTA buttons displayed a second inner pill from the hover layer resting inside the outline, and the CTA section's content stack sat off-center with inconsistent vertical spacing.
+   *Resolution:* Hid the gradient layer until interaction, re-centered the CTA container with flexible alignment, and synced spacing so the call-to-action headline and button align cleanly.
+
+3. **Unwanted Section Dividers**
+   *Files:* `style.css`
+   *Issue:* Newly introduced borders on the header and generic `section` elements surfaced as stark white lines across the layout and at the bottom of the fixed header.
+   *Resolution:* Removed the default section divider and header border, relying on existing background and glow effects for separation to eliminate the stray lines.
+
 ### 2025-10-03 Sweep
 1. **Missing Dimensions Controls**
    *Files:* `theme.json`

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,11 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.9 - 2025-10-04 =
+* **Navigation:** Reinstated the neon wobble-and-pulse hover treatment with a pink-to-blue gradient sweep that inverses the header animation while honouring reduced-motion preferences.
+* **Calls to Action:** Centered the CTA layout and kept the gradient fill layer hidden until interaction so the buttons no longer show a second pill inside the outline.
+* **Layout Polish:** Removed unintended divider borders from the header and section blocks to eliminate stray white lines across the page chrome.
+
 = 1.2.8 - 2025-10-03 =
 * **Editor Controls:** Enabled global spacing support flags and unit options in `theme.json` so the Dimensions panel exposes pa
 dding, margin, and block gap controls across custom marketing sections and core blocks using spacing presets.

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.7
+Version:       1.2.9
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital
@@ -86,11 +86,6 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     padding-right: clamp(24px, 5vw, 80px);
 }
 
-section {
-    border-bottom: 1px solid var(--text-secondary);
-}
-
-
 /* ==============================================================
 # Site Header & Navigation
 ============================================================== */
@@ -133,6 +128,18 @@ section {
     }
 }
 
+@keyframes nav-pulse {
+    0% {
+        text-shadow: 0 0 10px rgba(0, 229, 255, 0.45), 0 0 0 rgba(255, 0, 204, 0.35);
+    }
+    50% {
+        text-shadow: 0 0 16px rgba(0, 229, 255, 0.75), 0 0 12px rgba(255, 0, 204, 0.45);
+    }
+    100% {
+        text-shadow: 0 0 10px rgba(0, 229, 255, 0.45), 0 0 0 rgba(255, 0, 204, 0.35);
+    }
+}
+
 #masthead.site-header {
     padding: 15px 5%;
     display: flex;
@@ -146,7 +153,6 @@ section {
     transition: transform .4s cubic-bezier(.22,.61,.36,1), background-color 0.3s ease;
     background: rgba(0,0,0,0.8);
     backdrop-filter: blur(10px);
-    border-bottom: 2px solid var(--text-secondary);
     overflow: hidden; /* Hides the pseudo-element when it's outside */
 }
 
@@ -216,12 +222,6 @@ section {
     text-shadow: 0 0 10px var(--neon-cyan);
 }
 
-.main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover,
-.main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible {
-    color: var(--neon-cyan);
-    text-shadow: 0 0 5px var(--neon-cyan);
-}
-
 .main-navigation.wp-block-navigation {
     display: flex;
     align-items: center;
@@ -243,9 +243,24 @@ section {
     font-weight: 700;
     padding: 10px 5px;
     position: relative;
-    transition: color 0.3s ease, text-shadow 0.3s ease;
+    transition: color 0.3s ease, text-shadow 0.3s ease, transform 0.4s ease, background-position 0.45s cubic-bezier(0.77, 0, 0.175, 1);
     font-family: 'Nunito', sans-serif;
     font-size: 1.1em;
+    background-image: linear-gradient(90deg, var(--neon-magenta), var(--neon-cyan));
+    background-size: 200% 100%;
+    background-position: 100% 50%;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: currentColor;
+}
+
+.main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover,
+.main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible {
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    background-position: 0% 50%;
+    text-shadow: 0 0 10px rgba(0, 229, 255, 0.6), 0 0 18px rgba(255, 0, 204, 0.4);
+    animation: wobble 0.6s ease both, nav-pulse 1.6s ease-in-out infinite alternate;
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation__responsive-container-open,
@@ -312,8 +327,9 @@ section {
     inset: 0;
     background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
     border-radius: inherit;
-    transform: translateX(-101%);
-    transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1);
+    transform: translateX(-105%);
+    opacity: 0;
+    transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease;
     z-index: -1;
 }
 
@@ -324,6 +340,7 @@ section {
 .post-card .wp-block-read-more a:hover::before,
 .post-card .wp-block-read-more a:focus-visible::before {
     transform: translateX(0%);
+    opacity: 1;
 }
 
 .cta-button:focus-visible,
@@ -362,6 +379,19 @@ section {
     .post-card .wp-block-read-more a,
     .post-card .wp-block-read-more a::before {
         transition: none;
+    }
+
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content,
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content::before {
+        transition: none;
+    }
+
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover,
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible {
+        animation: none;
+        transform: none;
+        background-position: 0% 50%;
+        text-shadow: none;
     }
 
     .stars,


### PR DESCRIPTION
## Summary
- Reintroduce the neon navigation hover wobble with a reversed pink-to-blue gradient sweep and reduced-motion fallback.
- Center the CTA stack and hide the gradient overlay until interaction to remove the inner pill artifact.
- Drop unintended section/header borders and update project documentation with the latest sweep details.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8d7193bec8324bb070cb3e58aea3c