### PR TITLE
Improve CTA alignment and navigation hover contrast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-05):**
+    - Centered the CTA headline, kept the gradient pill layer hidden until interaction so CTA buttons render a single surface, and swapped the navigation hover gradient text fill for a neon underline that stays legible while wobbling.
 - **Latest (2025-10-04):**
     - Restored the neon navigation hover wobble with a reversed gradient sweep, re-centered the CTA layout, hid the standby gradient pill layer, and removed unintended header/section borders that introduced bright divider lines.
 - **Latest (2025-10-03):**

--- a/blocks/cta/style.css
+++ b/blocks/cta/style.css
@@ -23,6 +23,10 @@
 
 .wp-block-mccullough-digital-cta .section-title {
     margin-bottom: 0;
+    left: 0;
+    transform: none;
+    align-self: center;
+    margin-inline: auto;
 }
 
 .wp-block-mccullough-digital-cta .wp-block-buttons {

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,17 @@ This report now tracks the 2025-09-27 through 2025-10-03 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-05 Sweep
+1. **Navigation Hover Contrast Loss**
+   *Files:* `style.css`
+   *Issue:* The navigation wobble and pulse returned, but the gradient text fill rendered the links unreadable as it swept across each label.
+   *Resolution:* Replaced the gradient text fill with a neon underline animation that preserves the wobble/pulse motion while keeping the text color solid for consistent legibility.
+
+2. **CTA Alignment & Double-Pill Regression**
+   *Files:* `blocks/cta/style.css`, `style.css`, `editor-style.css`
+   *Issue:* The "Ready to Create?" heading drifted off-centre and the CTA buttons showed a second inner pill from the dormant gradient layer resting inside the outline.
+   *Resolution:* Reset the CTA heading positioning in both front-end and editor styles and hid the gradient layer until interaction, eliminating the extra pill while keeping the hover sweep intact.
+
 ### 2025-10-04 Sweep
 1. **Navigation Hover Animation Regression**
    *Files:* `style.css`

--- a/editor-style.css
+++ b/editor-style.css
@@ -39,6 +39,7 @@
     overflow: hidden;
     transition: all 0.3s ease;
     box-shadow: 0 0 10px rgba(0, 229, 255, 0.5);
+    isolation: isolate;
 }
 
 .editor-styles-wrapper .cta-button .btn-text,
@@ -51,14 +52,15 @@
 .editor-styles-wrapper .wp-block-button__link.cta-button::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0;
     background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
-    transform: translateX(-101%);
-    transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1);
-    z-index: 1;
+    border-radius: inherit;
+    transform: translateX(-110%);
+    opacity: 0;
+    visibility: hidden;
+    transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease, visibility 0s linear 0.5s;
+    transition-delay: 0s, 0s, 0.5s;
+    z-index: -1;
 }
 
 .editor-styles-wrapper .cta-button:focus-visible,
@@ -75,6 +77,9 @@
 .editor-styles-wrapper .wp-block-button__link.cta-button:focus-visible::before,
 .editor-styles-wrapper .wp-block-button__link.cta-button:hover::before {
     transform: translateX(0%);
+    opacity: 1;
+    visibility: visible;
+    transition-delay: 0s, 0s, 0s;
 }
 
 .editor-styles-wrapper .section-title {
@@ -239,6 +244,13 @@
     background: linear-gradient(45deg, var(--neon-cyan), var(--neon-magenta));
     text-align: center;
     border-radius: 20px;
+}
+
+.editor-styles-wrapper .cta-section .section-title {
+    left: 0;
+    transform: none;
+    align-self: center;
+    margin-inline: auto;
 }
 
 .editor-styles-wrapper .cta-section .cta-button,

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,10 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+ = 1.2.10 - 2025-10-05 =
+* **Navigation Hover Contrast:** Replaced the gradient text fill with a neon underline sweep so the wobble and pulse animations remain while the link copy stays readable.
+* **CTA Polish:** Recentred the "Ready to Create?" heading within the CTA block and kept the gradient pill layer hidden until interaction so the buttons no longer display a second inner pill at rest.
+
 = 1.2.9 - 2025-10-04 =
 * **Navigation:** Reinstated the neon wobble-and-pulse hover treatment with a pink-to-blue gradient sweep that inverses the header animation while honouring reduced-motion preferences.
 * **Calls to Action:** Centered the CTA layout and kept the gradient fill layer hidden until interaction so the buttons no longer show a second pill inside the outline.

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.9
+Version:       1.2.10
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital
@@ -243,24 +243,41 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     font-weight: 700;
     padding: 10px 5px;
     position: relative;
-    transition: color 0.3s ease, text-shadow 0.3s ease, transform 0.4s ease, background-position 0.45s cubic-bezier(0.77, 0, 0.175, 1);
+    transition: color 0.3s ease, text-shadow 0.3s ease, transform 0.4s ease;
     font-family: 'Nunito', sans-serif;
     font-size: 1.1em;
+}
+
+.main-navigation.wp-block-navigation .wp-block-navigation-item__content::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 3px;
+    border-radius: 999px;
     background-image: linear-gradient(90deg, var(--neon-magenta), var(--neon-cyan));
     background-size: 200% 100%;
     background-position: 100% 50%;
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: currentColor;
+    opacity: 0;
+    transform: scaleX(0.35);
+    transform-origin: center;
+    transition: opacity 0.25s ease, transform 0.45s cubic-bezier(0.77, 0, 0.175, 1), background-position 0.45s cubic-bezier(0.77, 0, 0.175, 1);
+    pointer-events: none;
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover,
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible {
-    color: transparent;
-    -webkit-text-fill-color: transparent;
-    background-position: 0% 50%;
+    color: #ffffff;
     text-shadow: 0 0 10px rgba(0, 229, 255, 0.6), 0 0 18px rgba(255, 0, 204, 0.4);
     animation: wobble 0.6s ease both, nav-pulse 1.6s ease-in-out infinite alternate;
+}
+
+.main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover::after,
+.main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible::after {
+    opacity: 1;
+    transform: scaleX(1);
+    background-position: 0% 50%;
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation__responsive-container-open,
@@ -300,6 +317,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     transition-timing-function: ease, ease, linear;
     transition-delay: 0s, 0s, 0s;
     box-shadow: 0 0 10px rgba(0, 229, 255, 0.5);
+    isolation: isolate;
 }
 
 .cta-button:hover,
@@ -327,9 +345,11 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     inset: 0;
     background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
     border-radius: inherit;
-    transform: translateX(-105%);
+    transform: translateX(-110%);
     opacity: 0;
-    transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease;
+    visibility: hidden;
+    transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease, visibility 0s linear 0.5s;
+    transition-delay: 0s, 0s, 0.5s;
     z-index: -1;
 }
 
@@ -341,6 +361,8 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .post-card .wp-block-read-more a:focus-visible::before {
     transform: translateX(0%);
     opacity: 1;
+    visibility: visible;
+    transition-delay: 0s, 0s, 0s;
 }
 
 .cta-button:focus-visible,
@@ -382,7 +404,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     }
 
     .main-navigation.wp-block-navigation .wp-block-navigation-item__content,
-    .main-navigation.wp-block-navigation .wp-block-navigation-item__content::before {
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content::after {
         transition: none;
     }
 
@@ -390,8 +412,14 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible {
         animation: none;
         transform: none;
-        background-position: 0% 50%;
         text-shadow: none;
+    }
+
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover::after,
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible::after {
+        transform: scaleX(1);
+        opacity: 1;
+        background-position: 50% 50%;
     }
 
     .stars,


### PR DESCRIPTION
## Summary
- center the CTA headline and hide the resting gradient layer so neon buttons sit on a single surface
- swap the navigation hover gradient text fill for a neon underline to keep the wobble/pulse animation readable
- mirror the fixes in editor styles and update the changelog and maintenance docs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8db51e5f88324a9127913d0f81200