### PR TITLE
Refine neon navigation and CTA styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-06):**
+    - Locked the primary navigation links to a solid cyan treatment with an intensified glow-and-pulse hover so the wobble anim
+      ation stays legible and energetic without reverting to gradient fills.
+    - Rebuilt the CTA button styling to render a single neon surface with a bloom halo, eliminating the nested dark pill while
+      keeping the hover lift consistent across hero, CTA, and read more links.
 - **Latest (2025-10-05):**
     - Centered the CTA headline, kept the gradient pill layer hidden until interaction so CTA buttons render a single surface, and swapped the navigation hover gradient text fill for a neon underline that stays legible while wobbling.
 - **Latest (2025-10-04):**

--- a/blocks/cta/style.css
+++ b/blocks/cta/style.css
@@ -41,17 +41,16 @@
 
 .wp-block-mccullough-digital-cta .wp-block-button__link,
 .wp-block-mccullough-digital-cta .cta-button {
-    border-color: #fff;
-    border-width: 2px;
-    box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
-    background: transparent;
-    color: #fff;
-    transition: all 0.3s ease;
+    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+    color: var(--background-dark);
+    border: none;
+    box-shadow: 0 0 18px rgba(255, 255, 255, 0.55), 0 0 32px rgba(255, 255, 255, 0.45);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link:hover,
 .wp-block-mccullough-digital-cta .cta-button:hover {
-    background: #fff;
-    color: var(--neon-magenta);
-    box-shadow: 0 0 20px #fff, 0 0 40px #fff;
+    transform: translateY(-3px) scale(1.02);
+    box-shadow: 0 0 28px rgba(255, 255, 255, 0.75), 0 0 48px rgba(255, 255, 255, 0.6);
+    filter: saturate(1.1);
 }

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,20 @@ This report now tracks the 2025-09-27 through 2025-10-03 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-06 Sweep
+1. **Navigation Glow Regression**
+   *Files:* `style.css`
+   *Issue:* The primary navigation reverted to muted white labels with a gradient underline, leaving the wobble animation visua
+   lly inconsistent with the neon palette and lacking the requested cyan glow.
+   *Resolution:* Set the default link color to the neon cyan token, tightened the underline to a solid cyan bar, and paired the
+   wobble hover animation with a cyan-only pulse so the links stay readable while delivering the requested glow.
+
+2. **Persistent Inner CTA Pills**
+   *Files:* `style.css`, `editor-style.css`, `blocks/cta/style.css`, `standalone.html`
+   *Issue:* CTA buttons still rendered a dark secondary pill beneath the gradient layer, producing the unwanted double-pill loo
+   k in both the hero and CTA sections.
+   *Resolution:* Redesigned the button styling to use a single gradient surface with a blurred halo, removed the inner outline, and synced the editor and standalone previews so the neon pill renders as one cohesive element.
+
 ### 2025-10-05 Sweep
 1. **Navigation Hover Contrast Loss**
    *Files:* `style.css`

--- a/editor-style.css
+++ b/editor-style.css
@@ -25,20 +25,22 @@
 
 .editor-styles-wrapper .cta-button,
 .editor-styles-wrapper .wp-block-button__link.cta-button {
-    display: inline-block;
-    padding: 15px 35px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 15px 38px;
     font-family: 'Nunito', sans-serif;
     font-weight: 700;
     font-size: 1.2rem;
-    color: var(--text-primary);
+    color: var(--background-dark);
     text-decoration: none;
-    background: transparent;
-    border: 2px solid var(--neon-cyan);
+    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+    border: none;
     border-radius: 50px;
     position: relative;
-    overflow: hidden;
-    transition: all 0.3s ease;
-    box-shadow: 0 0 10px rgba(0, 229, 255, 0.5);
+    overflow: visible;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+    box-shadow: 0 0 18px rgba(0, 229, 255, 0.55), 0 0 32px rgba(255, 0, 224, 0.45);
     isolation: isolate;
 }
 
@@ -52,34 +54,30 @@
 .editor-styles-wrapper .wp-block-button__link.cta-button::before {
     content: '';
     position: absolute;
-    inset: 0;
-    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+    inset: -6px;
     border-radius: inherit;
-    transform: translateX(-110%);
-    opacity: 0;
-    visibility: hidden;
-    transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease, visibility 0s linear 0.5s;
-    transition-delay: 0s, 0s, 0.5s;
+    background: linear-gradient(90deg, rgba(0, 229, 255, 0.75), rgba(255, 0, 224, 0.65));
+    filter: blur(18px);
+    opacity: 0.7;
     z-index: -1;
+    transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .editor-styles-wrapper .cta-button:focus-visible,
 .editor-styles-wrapper .cta-button:hover,
 .editor-styles-wrapper .wp-block-button__link.cta-button:focus-visible,
 .editor-styles-wrapper .wp-block-button__link.cta-button:hover {
-    color: var(--background-dark);
-    box-shadow: 0 0 20px var(--neon-cyan), 0 0 40px var(--neon-cyan);
-    transform: translateY(-3px);
+    transform: translateY(-3px) scale(1.02);
+    box-shadow: 0 0 28px rgba(0, 229, 255, 0.7), 0 0 48px rgba(255, 0, 224, 0.55);
+    filter: saturate(1.1);
 }
 
 .editor-styles-wrapper .cta-button:focus-visible::before,
 .editor-styles-wrapper .cta-button:hover::before,
 .editor-styles-wrapper .wp-block-button__link.cta-button:focus-visible::before,
 .editor-styles-wrapper .wp-block-button__link.cta-button:hover::before {
-    transform: translateX(0%);
-    opacity: 1;
-    visibility: visible;
-    transition-delay: 0s, 0s, 0s;
+    opacity: 0.9;
+    transform: scale(1.05);
 }
 
 .editor-styles-wrapper .section-title {

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,12 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+ = 1.2.11 - 2025-10-06 =
+* **Navigation Glow:** Locked the primary menu links to a solid cyan neon treatment with a stronger pulse so the wobble effect
+stays bright and legible.
+* **CTA Surface Cleanup:** Rebuilt the CTA, hero, and read-more buttons around a single gradient surface with a halo glow, remo
+ving the unwanted inner pill across front-end, editor, and standalone previews.
+
  = 1.2.10 - 2025-10-05 =
 * **Navigation Hover Contrast:** Replaced the gradient text fill with a neon underline sweep so the wobble and pulse animations remain while the link copy stays readable.
 * **CTA Polish:** Recentred the "Ready to Create?" heading within the CTA block and kept the gradient pill layer hidden until interaction so the buttons no longer display a second inner pill at rest.

--- a/standalone.html
+++ b/standalone.html
@@ -97,6 +97,22 @@
             50% { transform: scale(1.08); }
         }
 
+        @keyframes wobble {
+            0% { transform: rotate(0deg); }
+            15% { transform: rotate(-5deg); }
+            30% { transform: rotate(5deg); }
+            45% { transform: rotate(-3deg); }
+            60% { transform: rotate(3deg); }
+            75% { transform: rotate(-1deg); }
+            100% { transform: rotate(0deg); }
+        }
+
+        @keyframes nav-pulse {
+            0% { text-shadow: 0 0 10px rgba(0, 229, 255, 0.45); }
+            50% { text-shadow: 0 0 18px rgba(0, 229, 255, 0.9); }
+            100% { text-shadow: 0 0 10px rgba(0, 229, 255, 0.45); }
+        }
+
         /* @keyframes soft-glow-pulse {
             0% { text-shadow: 0 0 15px var(--neon-cyan), 0 0 25px var(--neon-cyan); }
             50% { text-shadow: 0 0 25px var(--neon-cyan), 0 0 40px var(--neon-cyan), 0 0 50px var(--neon-magenta); }
@@ -195,19 +211,40 @@
             gap: 25px;
         }
         #primary-menu li a {
-            color: #ffffff;
+            color: var(--neon-cyan);
             text-decoration: none;
             font-weight: 700;
             padding: 10px 5px;
             position: relative;
-            transition: color 0.3s ease;
+            transition: color 0.3s ease, text-shadow 0.3s ease, transform 0.4s ease;
             font-family: 'Nunito', sans-serif;
             font-size: 1.1em;
+            text-shadow: 0 0 12px rgba(0, 229, 255, 0.55);
         }
-        #primary-menu li a:hover {
+        #primary-menu li a::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            height: 3px;
+            border-radius: 999px;
+            background: var(--neon-cyan);
+            opacity: 0;
+            transform: scaleX(0.35);
+            transform-origin: center;
+            transition: opacity 0.25s ease, transform 0.45s cubic-bezier(0.77, 0, 0.175, 1);
+        }
+        #primary-menu li a:hover,
+        #primary-menu li a:focus-visible {
             color: var(--neon-cyan);
-            text-shadow: 0 0 8px var(--neon-cyan);
-            animation: shake-zoom 0.4s ease-in-out infinite;
+            text-shadow: 0 0 12px rgba(0, 229, 255, 0.7), 0 0 24px rgba(0, 229, 255, 0.55);
+            animation: wobble 0.6s ease both, nav-pulse 1.6s ease-in-out infinite alternate;
+        }
+        #primary-menu li a:hover::after,
+        #primary-menu li a:focus-visible::after {
+            opacity: 1;
+            transform: scaleX(1);
         }
 
         .menu-toggle {
@@ -356,47 +393,46 @@
 
         /* --- CTA Button Styles --- */
         .cta-button {
-            display: inline-block;
-            padding: 15px 35px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 15px 38px;
             font-family: 'Nunito', sans-serif;
             font-weight: 700;
             font-size: 1.2rem;
-            color: #fff;
-            text-decoration: none;
-            background: transparent;
-            border: 2px solid var(--neon-cyan);
-            border-radius: 50px; /* Softer, pill-shaped button */
-            position: relative;
-            overflow: hidden;
-            transition: all 0.3s ease;
-            box-shadow: 0 0 10px rgba(0, 229, 255, 0.5);
-        }
-        .cta-button:hover {
             color: var(--background-dark);
-            box-shadow: 0 0 20px var(--neon-cyan), 0 0 40px var(--neon-cyan);
-            transform: translateY(-3px);
+            text-decoration: none;
+            background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+            border-radius: 50px;
+            border: none;
+            position: relative;
+            overflow: visible;
+            transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+            box-shadow: 0 0 18px rgba(0, 229, 255, 0.55), 0 0 32px rgba(255, 0, 224, 0.45);
         }
-        
         .cta-button .btn-text {
             position: relative;
             z-index: 2;
         }
-
         .cta-button::before {
             content: '';
             position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
-            transform: translateX(-101%);
-            transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1);
-            z-index: 1;
+            inset: -6px;
+            border-radius: inherit;
+            background: linear-gradient(90deg, rgba(0, 229, 255, 0.75), rgba(255, 0, 224, 0.65));
+            filter: blur(18px);
+            opacity: 0.7;
+            z-index: -1;
+            transition: opacity 0.3s ease, transform 0.3s ease;
         }
-        
+        .cta-button:hover {
+            transform: translateY(-3px) scale(1.02);
+            box-shadow: 0 0 28px rgba(0, 229, 255, 0.7), 0 0 48px rgba(255, 0, 224, 0.55);
+            filter: saturate(1.1);
+        }
         .cta-button:hover::before {
-            transform: translateX(0%);
+            opacity: 0.9;
+            transform: scale(1.05);
         }
 
         /* --- Services Section --- */

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.10
+Version:       1.2.11
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital
@@ -130,13 +130,13 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 
 @keyframes nav-pulse {
     0% {
-        text-shadow: 0 0 10px rgba(0, 229, 255, 0.45), 0 0 0 rgba(255, 0, 204, 0.35);
+        text-shadow: 0 0 10px rgba(0, 229, 255, 0.45);
     }
     50% {
-        text-shadow: 0 0 16px rgba(0, 229, 255, 0.75), 0 0 12px rgba(255, 0, 204, 0.45);
+        text-shadow: 0 0 18px rgba(0, 229, 255, 0.9);
     }
     100% {
-        text-shadow: 0 0 10px rgba(0, 229, 255, 0.45), 0 0 0 rgba(255, 0, 204, 0.35);
+        text-shadow: 0 0 10px rgba(0, 229, 255, 0.45);
     }
 }
 
@@ -238,7 +238,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content {
-    color: var(--text-primary);
+    color: var(--neon-cyan);
     text-decoration: none;
     font-weight: 700;
     padding: 10px 5px;
@@ -246,6 +246,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     transition: color 0.3s ease, text-shadow 0.3s ease, transform 0.4s ease;
     font-family: 'Nunito', sans-serif;
     font-size: 1.1em;
+    text-shadow: 0 0 12px rgba(0, 229, 255, 0.55);
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content::after {
@@ -256,20 +257,18 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     bottom: 0;
     height: 3px;
     border-radius: 999px;
-    background-image: linear-gradient(90deg, var(--neon-magenta), var(--neon-cyan));
-    background-size: 200% 100%;
-    background-position: 100% 50%;
+    background: var(--neon-cyan);
     opacity: 0;
     transform: scaleX(0.35);
     transform-origin: center;
-    transition: opacity 0.25s ease, transform 0.45s cubic-bezier(0.77, 0, 0.175, 1), background-position 0.45s cubic-bezier(0.77, 0, 0.175, 1);
+    transition: opacity 0.25s ease, transform 0.45s cubic-bezier(0.77, 0, 0.175, 1);
     pointer-events: none;
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover,
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible {
-    color: #ffffff;
-    text-shadow: 0 0 10px rgba(0, 229, 255, 0.6), 0 0 18px rgba(255, 0, 204, 0.4);
+    color: var(--neon-cyan);
+    text-shadow: 0 0 12px rgba(0, 229, 255, 0.7), 0 0 24px rgba(0, 229, 255, 0.55);
     animation: wobble 0.6s ease both, nav-pulse 1.6s ease-in-out infinite alternate;
 }
 
@@ -277,7 +276,6 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible::after {
     opacity: 1;
     transform: scaleX(1);
-    background-position: 0% 50%;
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation__responsive-container-open,
@@ -297,42 +295,32 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 }
 
 /* --- CTA Button Styles --- */
+
 .cta-button,
 .wp-block-button__link.cta-button,
 .post-card .wp-block-read-more a {
-    display: inline-block;
-    padding: 15px 35px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 15px 38px;
     font-family: 'Nunito', sans-serif;
     font-weight: 700;
     font-size: 1.2rem;
-    color: var(--text-primary);
+    color: var(--background-dark);
     text-decoration: none;
-    background: transparent;
-    border: 2px solid var(--neon-cyan);
-    border-radius: 50px; /* Softer, pill-shaped button */
+    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+    border: none;
+    border-radius: 50px;
     position: relative;
-    overflow: hidden;
-    transition-property: transform, box-shadow, color;
-    transition-duration: 0.3s, 0.3s, 0s;
-    transition-timing-function: ease, ease, linear;
-    transition-delay: 0s, 0s, 0s;
-    box-shadow: 0 0 10px rgba(0, 229, 255, 0.5);
+    overflow: visible;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+    box-shadow: 0 0 18px rgba(0, 229, 255, 0.55), 0 0 32px rgba(255, 0, 224, 0.45);
     isolation: isolate;
 }
 
-.cta-button:hover,
-.cta-button:focus-visible,
-.wp-block-button__link.cta-button:hover,
-.wp-block-button__link.cta-button:focus-visible,
-.post-card .wp-block-read-more a:hover,
-.post-card .wp-block-read-more a:focus-visible {
-    color: var(--background-dark);
-    box-shadow: 0 0 20px var(--neon-cyan), 0 0 40px var(--neon-cyan);
-    transform: translateY(-3px);
-    transition-delay: 0s, 0s, 0.45s;
-}
-
-.cta-button .btn-text {
+.cta-button .btn-text,
+.wp-block-button__link.cta-button .btn-text,
+.post-card .wp-block-read-more a .btn-text {
     position: relative;
     z-index: 2;
 }
@@ -342,15 +330,24 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .post-card .wp-block-read-more a::before {
     content: '';
     position: absolute;
-    inset: 0;
-    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+    inset: -6px;
     border-radius: inherit;
-    transform: translateX(-110%);
-    opacity: 0;
-    visibility: hidden;
-    transition: transform 0.5s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.2s ease, visibility 0s linear 0.5s;
-    transition-delay: 0s, 0s, 0.5s;
+    background: linear-gradient(90deg, rgba(0, 229, 255, 0.75), rgba(255, 0, 224, 0.65));
+    filter: blur(18px);
+    opacity: 0.7;
     z-index: -1;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.cta-button:hover,
+.cta-button:focus-visible,
+.wp-block-button__link.cta-button:hover,
+.wp-block-button__link.cta-button:focus-visible,
+.post-card .wp-block-read-more a:hover,
+.post-card .wp-block-read-more a:focus-visible {
+    transform: translateY(-3px) scale(1.02);
+    box-shadow: 0 0 28px rgba(0, 229, 255, 0.7), 0 0 48px rgba(255, 0, 224, 0.55);
+    filter: saturate(1.1);
 }
 
 .cta-button:hover::before,
@@ -359,10 +356,8 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .wp-block-button__link.cta-button:focus-visible::before,
 .post-card .wp-block-read-more a:hover::before,
 .post-card .wp-block-read-more a:focus-visible::before {
-    transform: translateX(0%);
-    opacity: 1;
-    visibility: visible;
-    transition-delay: 0s, 0s, 0s;
+    opacity: 0.9;
+    transform: scale(1.05);
 }
 
 .cta-button:focus-visible,
@@ -401,25 +396,6 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     .post-card .wp-block-read-more a,
     .post-card .wp-block-read-more a::before {
         transition: none;
-    }
-
-    .main-navigation.wp-block-navigation .wp-block-navigation-item__content,
-    .main-navigation.wp-block-navigation .wp-block-navigation-item__content::after {
-        transition: none;
-    }
-
-    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover,
-    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible {
-        animation: none;
-        transform: none;
-        text-shadow: none;
-    }
-
-    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover::after,
-    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible::after {
-        transform: scaleX(1);
-        opacity: 1;
-        background-position: 50% 50%;
     }
 
     .stars,


### PR DESCRIPTION
## Summary
- lock the primary navigation links to a solid cyan treatment with a glowing pulse while preserving the wobble animation
- rebuild CTA button styling across front end, editor, and preview so the gradient renders as a single pill with a bloom halo
- update docs to note the navigation glow and single-surface CTA changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8e0855ef88324bf5ff6b991ce470c