### PR TITLE
Refine navigation palette and CTA pill hover treatments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-07):**
+    - Kept the primary navigation labels white at rest, removed the sweep underline, and reserved the neon cyan wobble-and-pulse animation for hover/focus states only.
+    - Reimagined the CTA button styling across the theme so the single pill base fills with a cyan-to-magenta gradient on hover while the lettering gains a pulsing glow.
 - **Latest (2025-10-06):**
     - Locked the primary navigation links to a solid cyan treatment with an intensified glow-and-pulse hover so the wobble anim
       ation stays legible and energetic without reverting to gradient fills.

--- a/blocks/cta/style.css
+++ b/blocks/cta/style.css
@@ -41,16 +41,19 @@
 
 .wp-block-mccullough-digital-cta .wp-block-button__link,
 .wp-block-mccullough-digital-cta .cta-button {
-    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
-    color: var(--background-dark);
-    border: none;
-    box-shadow: 0 0 18px rgba(255, 255, 255, 0.55), 0 0 32px rgba(255, 255, 255, 0.45);
-    transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+    background: var(--surface-dark);
+    color: var(--text-primary);
+    border: 2px solid rgba(230, 241, 255, 0.18);
+    box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65);
+    transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease, border-color 0.35s ease;
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link:hover,
-.wp-block-mccullough-digital-cta .cta-button:hover {
-    transform: translateY(-3px) scale(1.02);
-    box-shadow: 0 0 28px rgba(255, 255, 255, 0.75), 0 0 48px rgba(255, 255, 255, 0.6);
-    filter: saturate(1.1);
+.wp-block-mccullough-digital-cta .cta-button:hover,
+.wp-block-mccullough-digital-cta .wp-block-button__link:focus-visible,
+.wp-block-mccullough-digital-cta .cta-button:focus-visible {
+    transform: translateY(-4px) scale(1.03);
+    color: var(--background-dark);
+    border-color: transparent;
+    box-shadow: 0 18px 40px rgba(0, 229, 255, 0.35), 0 0 36px rgba(255, 0, 224, 0.3);
 }

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,17 @@ This report now tracks the 2025-09-27 through 2025-10-03 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-07 Sweep
+1. **Navigation Contrast Request**
+   *Files:* `style.css`
+   *Issue:* The primary menu labels defaulted to neon cyan with an animated underline, so the hover wobble never transitioned from the requested resting white state and the sweep underline remained visible.
+   *Resolution:* Reset the base link color to the primary text token, removed the sweep underline pseudo-element, and limited the wobble/pulse animation to hover and focus so links stay white until interaction.
+
+2. **CTA Pill Gradient Fill Timing**
+   *Files:* `style.css`, `editor-style.css`, `blocks/cta/style.css`, `standalone.html`
+   *Issue:* CTA buttons still rendered as fully gradient-filled pills at rest with halo effects that implied an inner pill, and the hover text lacked the requested playful treatment.
+   *Resolution:* Rebuilt the button styling to rest on a single dark pill that floods with a cyan-to-magenta gradient on hover, added glowing letter spacing animations, synced the editor and standalone previews, and updated CTA block overrides to avoid reintroducing the double-pill look.
+
 ### 2025-10-06 Sweep
 1. **Navigation Glow Regression**
    *Files:* `style.css`

--- a/editor-style.css
+++ b/editor-style.css
@@ -28,56 +28,82 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 15px 38px;
+    padding: 15px 42px;
     font-family: 'Nunito', sans-serif;
     font-weight: 700;
     font-size: 1.2rem;
-    color: var(--background-dark);
+    color: var(--text-primary);
     text-decoration: none;
-    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
-    border: none;
-    border-radius: 50px;
+    background: var(--surface-dark);
+    border: 2px solid rgba(230, 241, 255, 0.18);
+    border-radius: 999px;
     position: relative;
-    overflow: visible;
-    transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-    box-shadow: 0 0 18px rgba(0, 229, 255, 0.55), 0 0 32px rgba(255, 0, 224, 0.45);
+    overflow: hidden;
+    transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease, border-color 0.35s ease;
+    box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65);
+    letter-spacing: 0.02em;
     isolation: isolate;
 }
 
 .editor-styles-wrapper .cta-button .btn-text,
 .editor-styles-wrapper .wp-block-button__link.cta-button .btn-text {
     position: relative;
-    z-index: 2;
+    z-index: 1;
+    transition: letter-spacing 0.35s ease, text-shadow 0.35s ease, transform 0.35s ease;
 }
 
 .editor-styles-wrapper .cta-button::before,
 .editor-styles-wrapper .wp-block-button__link.cta-button::before {
     content: '';
     position: absolute;
-    inset: -6px;
+    inset: 0;
     border-radius: inherit;
-    background: linear-gradient(90deg, rgba(0, 229, 255, 0.75), rgba(255, 0, 224, 0.65));
-    filter: blur(18px);
-    opacity: 0.7;
+    background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta), var(--deep-purple));
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 0.45s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.4s ease;
+    opacity: 0;
+    z-index: 0;
+}
+
+.editor-styles-wrapper .cta-button::after,
+.editor-styles-wrapper .wp-block-button__link.cta-button::after {
+    content: '';
+    position: absolute;
+    inset: -18px;
+    border-radius: inherit;
+    background: radial-gradient(circle at 30% 20%, rgba(0, 229, 255, 0.45), transparent 60%),
+        radial-gradient(circle at 70% 80%, rgba(255, 0, 224, 0.4), transparent 65%);
+    opacity: 0;
+    transform: scale(0.85);
+    transition: opacity 0.45s ease, transform 0.45s ease;
     z-index: -1;
-    transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .editor-styles-wrapper .cta-button:focus-visible,
 .editor-styles-wrapper .cta-button:hover,
 .editor-styles-wrapper .wp-block-button__link.cta-button:focus-visible,
 .editor-styles-wrapper .wp-block-button__link.cta-button:hover {
-    transform: translateY(-3px) scale(1.02);
-    box-shadow: 0 0 28px rgba(0, 229, 255, 0.7), 0 0 48px rgba(255, 0, 224, 0.55);
-    filter: saturate(1.1);
+    transform: translateY(-4px) scale(1.03);
+    color: var(--background-dark);
+    border-color: transparent;
+    box-shadow: 0 18px 40px rgba(0, 229, 255, 0.35), 0 0 36px rgba(255, 0, 224, 0.3);
 }
 
 .editor-styles-wrapper .cta-button:focus-visible::before,
 .editor-styles-wrapper .cta-button:hover::before,
 .editor-styles-wrapper .wp-block-button__link.cta-button:focus-visible::before,
 .editor-styles-wrapper .wp-block-button__link.cta-button:hover::before {
-    opacity: 0.9;
-    transform: scale(1.05);
+    transform: scaleX(1);
+    opacity: 1;
+}
+
+.editor-styles-wrapper .cta-button:focus-visible::after,
+.editor-styles-wrapper .cta-button:hover::after,
+.editor-styles-wrapper .wp-block-button__link.cta-button:focus-visible::after,
+.editor-styles-wrapper .wp-block-button__link.cta-button:hover::after {
+    opacity: 0.95;
+    transform: scale(1);
 }
 
 .editor-styles-wrapper .section-title {

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,10 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+ = 1.2.12 - 2025-10-07 =
+* **Navigation Palette Reset:** Kept primary menu links white at rest and removed the cyan sweep underline so the hover wobble now transitions into a neon-blue glow only when links are engaged.
+* **Hover-Fill CTA Pills:** Rebuilt CTA, hero, and read-more buttons to rest on a single dark pill that floods with a cyan-to-magenta gradient on hover while the lettering pulses and spaces out for extra flair.
+
  = 1.2.11 - 2025-10-06 =
 * **Navigation Glow:** Locked the primary menu links to a solid cyan neon treatment with a stronger pulse so the wobble effect
 stays bright and legible.

--- a/standalone.html
+++ b/standalone.html
@@ -113,6 +113,15 @@
             100% { text-shadow: 0 0 10px rgba(0, 229, 255, 0.45); }
         }
 
+        @keyframes glyph-glow {
+            0% {
+                text-shadow: 0 0 12px rgba(0, 229, 255, 0.6), 0 0 20px rgba(255, 0, 224, 0.55);
+            }
+            100% {
+                text-shadow: 0 0 18px rgba(0, 229, 255, 0.9), 0 0 32px rgba(255, 0, 224, 0.85);
+            }
+        }
+
         /* @keyframes soft-glow-pulse {
             0% { text-shadow: 0 0 15px var(--neon-cyan), 0 0 25px var(--neon-cyan); }
             50% { text-shadow: 0 0 25px var(--neon-cyan), 0 0 40px var(--neon-cyan), 0 0 50px var(--neon-magenta); }
@@ -396,43 +405,74 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            padding: 15px 38px;
+            padding: 15px 42px;
             font-family: 'Nunito', sans-serif;
             font-weight: 700;
             font-size: 1.2rem;
-            color: var(--background-dark);
+            color: var(--text-primary);
             text-decoration: none;
-            background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
-            border-radius: 50px;
-            border: none;
+            background: var(--surface-dark);
+            border-radius: 999px;
+            border: 2px solid rgba(230, 241, 255, 0.18);
             position: relative;
-            overflow: visible;
-            transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-            box-shadow: 0 0 18px rgba(0, 229, 255, 0.55), 0 0 32px rgba(255, 0, 224, 0.45);
+            overflow: hidden;
+            transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease, border-color 0.35s ease;
+            box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65);
+            letter-spacing: 0.02em;
+            isolation: isolate;
         }
         .cta-button .btn-text {
             position: relative;
-            z-index: 2;
+            z-index: 1;
+            transition: letter-spacing 0.35s ease, text-shadow 0.35s ease, transform 0.35s ease;
         }
         .cta-button::before {
             content: '';
             position: absolute;
-            inset: -6px;
+            inset: 0;
             border-radius: inherit;
-            background: linear-gradient(90deg, rgba(0, 229, 255, 0.75), rgba(255, 0, 224, 0.65));
-            filter: blur(18px);
-            opacity: 0.7;
+            background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta), var(--deep-purple));
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.45s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.4s ease;
+            opacity: 0;
+            z-index: 0;
+        }
+        .cta-button::after {
+            content: '';
+            position: absolute;
+            inset: -18px;
+            border-radius: inherit;
+            background: radial-gradient(circle at 30% 20%, rgba(0, 229, 255, 0.45), transparent 60%),
+                radial-gradient(circle at 70% 80%, rgba(255, 0, 224, 0.4), transparent 65%);
+            opacity: 0;
+            transform: scale(0.85);
+            transition: opacity 0.45s ease, transform 0.45s ease;
             z-index: -1;
-            transition: opacity 0.3s ease, transform 0.3s ease;
         }
-        .cta-button:hover {
-            transform: translateY(-3px) scale(1.02);
-            box-shadow: 0 0 28px rgba(0, 229, 255, 0.7), 0 0 48px rgba(255, 0, 224, 0.55);
-            filter: saturate(1.1);
+        .cta-button:hover,
+        .cta-button:focus-visible {
+            transform: translateY(-4px) scale(1.03);
+            color: var(--background-dark);
+            border-color: transparent;
+            box-shadow: 0 18px 40px rgba(0, 229, 255, 0.35), 0 0 36px rgba(255, 0, 224, 0.3);
         }
-        .cta-button:hover::before {
-            opacity: 0.9;
-            transform: scale(1.05);
+        .cta-button:hover::before,
+        .cta-button:focus-visible::before {
+            transform: scaleX(1);
+            opacity: 1;
+        }
+        .cta-button:hover::after,
+        .cta-button:focus-visible::after {
+            opacity: 0.95;
+            transform: scale(1);
+        }
+        .cta-button:hover .btn-text,
+        .cta-button:focus-visible .btn-text {
+            letter-spacing: 0.14em;
+            text-shadow: 0 0 16px rgba(0, 229, 255, 0.9), 0 0 28px rgba(255, 0, 224, 0.75);
+            transform: translateX(1px);
+            animation: glyph-glow 1.6s ease-in-out infinite alternate;
         }
 
         /* --- Services Section --- */

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.11
+Version:       1.2.12
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital
@@ -119,15 +119,6 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     100% { transform: rotate(0deg); }
 }
 
-@keyframes text-sweep {
-    0% {
-        background-position: 100% 50%;
-    }
-    100% {
-        background-position: -100% 50%;
-    }
-}
-
 @keyframes nav-pulse {
     0% {
         text-shadow: 0 0 10px rgba(0, 229, 255, 0.45);
@@ -238,7 +229,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content {
-    color: var(--neon-cyan);
+    color: var(--text-primary);
     text-decoration: none;
     font-weight: 700;
     padding: 10px 5px;
@@ -246,23 +237,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     transition: color 0.3s ease, text-shadow 0.3s ease, transform 0.4s ease;
     font-family: 'Nunito', sans-serif;
     font-size: 1.1em;
-    text-shadow: 0 0 12px rgba(0, 229, 255, 0.55);
-}
-
-.main-navigation.wp-block-navigation .wp-block-navigation-item__content::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 3px;
-    border-radius: 999px;
-    background: var(--neon-cyan);
-    opacity: 0;
-    transform: scaleX(0.35);
-    transform-origin: center;
-    transition: opacity 0.25s ease, transform 0.45s cubic-bezier(0.77, 0, 0.175, 1);
-    pointer-events: none;
+    text-shadow: 0 0 10px rgba(230, 241, 255, 0.25);
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover,
@@ -270,12 +245,6 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     color: var(--neon-cyan);
     text-shadow: 0 0 12px rgba(0, 229, 255, 0.7), 0 0 24px rgba(0, 229, 255, 0.55);
     animation: wobble 0.6s ease both, nav-pulse 1.6s ease-in-out infinite alternate;
-}
-
-.main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover::after,
-.main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible::after {
-    opacity: 1;
-    transform: scaleX(1);
 }
 
 .main-navigation.wp-block-navigation .wp-block-navigation__responsive-container-open,
@@ -296,25 +265,27 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 
 /* --- CTA Button Styles --- */
 
+
 .cta-button,
 .wp-block-button__link.cta-button,
 .post-card .wp-block-read-more a {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 15px 38px;
+    padding: 15px 42px;
     font-family: 'Nunito', sans-serif;
     font-weight: 700;
     font-size: 1.2rem;
-    color: var(--background-dark);
+    color: var(--text-primary);
     text-decoration: none;
-    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
-    border: none;
-    border-radius: 50px;
+    background: var(--surface-dark);
+    border: 2px solid rgba(230, 241, 255, 0.18);
+    border-radius: 999px;
     position: relative;
-    overflow: visible;
-    transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
-    box-shadow: 0 0 18px rgba(0, 229, 255, 0.55), 0 0 32px rgba(255, 0, 224, 0.45);
+    overflow: hidden;
+    transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease, border-color 0.35s ease;
+    box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65);
+    letter-spacing: 0.02em;
     isolation: isolate;
 }
 
@@ -322,7 +293,8 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .wp-block-button__link.cta-button .btn-text,
 .post-card .wp-block-read-more a .btn-text {
     position: relative;
-    z-index: 2;
+    z-index: 1;
+    transition: letter-spacing 0.35s ease, text-shadow 0.35s ease, transform 0.35s ease;
 }
 
 .cta-button::before,
@@ -330,13 +302,29 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .post-card .wp-block-read-more a::before {
     content: '';
     position: absolute;
-    inset: -6px;
+    inset: 0;
     border-radius: inherit;
-    background: linear-gradient(90deg, rgba(0, 229, 255, 0.75), rgba(255, 0, 224, 0.65));
-    filter: blur(18px);
-    opacity: 0.7;
+    background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta), var(--deep-purple));
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 0.45s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.4s ease;
+    opacity: 0;
+    z-index: 0;
+}
+
+.cta-button::after,
+.wp-block-button__link.cta-button::after,
+.post-card .wp-block-read-more a::after {
+    content: '';
+    position: absolute;
+    inset: -18px;
+    border-radius: inherit;
+    background: radial-gradient(circle at 30% 20%, rgba(0, 229, 255, 0.45), transparent 60%),
+        radial-gradient(circle at 70% 80%, rgba(255, 0, 224, 0.4), transparent 65%);
+    opacity: 0;
+    transform: scale(0.85);
+    transition: opacity 0.45s ease, transform 0.45s ease;
     z-index: -1;
-    transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .cta-button:hover,
@@ -345,9 +333,10 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .wp-block-button__link.cta-button:focus-visible,
 .post-card .wp-block-read-more a:hover,
 .post-card .wp-block-read-more a:focus-visible {
-    transform: translateY(-3px) scale(1.02);
-    box-shadow: 0 0 28px rgba(0, 229, 255, 0.7), 0 0 48px rgba(255, 0, 224, 0.55);
-    filter: saturate(1.1);
+    transform: translateY(-4px) scale(1.03);
+    color: var(--background-dark);
+    border-color: transparent;
+    box-shadow: 0 18px 40px rgba(0, 229, 255, 0.35), 0 0 36px rgba(255, 0, 224, 0.3);
 }
 
 .cta-button:hover::before,
@@ -356,8 +345,30 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .wp-block-button__link.cta-button:focus-visible::before,
 .post-card .wp-block-read-more a:hover::before,
 .post-card .wp-block-read-more a:focus-visible::before {
-    opacity: 0.9;
-    transform: scale(1.05);
+    transform: scaleX(1);
+    opacity: 1;
+}
+
+.cta-button:hover::after,
+.cta-button:focus-visible::after,
+.wp-block-button__link.cta-button:hover::after,
+.wp-block-button__link.cta-button:focus-visible::after,
+.post-card .wp-block-read-more a:hover::after,
+.post-card .wp-block-read-more a:focus-visible::after {
+    opacity: 0.95;
+    transform: scale(1);
+}
+
+.cta-button:hover .btn-text,
+.cta-button:focus-visible .btn-text,
+.wp-block-button__link.cta-button:hover .btn-text,
+.wp-block-button__link.cta-button:focus-visible .btn-text,
+.post-card .wp-block-read-more a:hover .btn-text,
+.post-card .wp-block-read-more a:focus-visible .btn-text {
+    letter-spacing: 0.14em;
+    text-shadow: 0 0 16px rgba(0, 229, 255, 0.9), 0 0 28px rgba(255, 0, 224, 0.75);
+    transform: translateX(1px);
+    animation: glyph-glow 1.6s ease-in-out infinite alternate;
 }
 
 .cta-button:focus-visible,
@@ -386,16 +397,39 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     to   { background-position: 0 -2000px; }
 }
 
+@keyframes glyph-glow {
+    0% {
+        text-shadow: 0 0 12px rgba(0, 229, 255, 0.6), 0 0 20px rgba(255, 0, 224, 0.55);
+    }
+    100% {
+        text-shadow: 0 0 18px rgba(0, 229, 255, 0.9), 0 0 32px rgba(255, 0, 224, 0.85);
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     #masthead.site-header,
     #masthead.site-header::before,
     .cta-button,
     .cta-button::before,
+    .cta-button::after,
     .wp-block-button__link.cta-button,
     .wp-block-button__link.cta-button::before,
+    .wp-block-button__link.cta-button::after,
     .post-card .wp-block-read-more a,
-    .post-card .wp-block-read-more a::before {
+    .post-card .wp-block-read-more a::before,
+    .post-card .wp-block-read-more a::after {
         transition: none;
+    }
+
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:hover,
+    .main-navigation.wp-block-navigation .wp-block-navigation-item__content:focus-visible,
+    .cta-button:hover .btn-text,
+    .cta-button:focus-visible .btn-text,
+    .wp-block-button__link.cta-button:hover .btn-text,
+    .wp-block-button__link.cta-button:focus-visible .btn-text,
+    .post-card .wp-block-read-more a:hover .btn-text,
+    .post-card .wp-block-read-more a:focus-visible .btn-text {
+        animation: none;
     }
 
     .stars,


### PR DESCRIPTION
## Summary
- keep the primary navigation links white at rest, remove the sweep underline, and confine the wobble/glow animation to hover states
- rebuild the CTA/hero/read-more pill styling so a single dark base fills with a cyan-to-magenta gradient and glowing text on hover across front end, editor, and standalone preview
- document the styling updates in AGENTS.md, bug-report.md, and readme.txt

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8e4affc5883248c6784c57c2d2538