### PR TITLE
Sync front-end CTA gradient treatment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-08):**
+    - Synced the front-end CTA, hero, and read more buttons with the editor treatment so the gradient flood, halo glow, and hover color swap all animate identically across the theme, block styles, and standalone preview.
 - **Latest (2025-10-07):**
     - Kept the primary navigation labels white at rest, removed the sweep underline, and reserved the neon cyan wobble-and-pulse animation for hover/focus states only.
     - Reimagined the CTA button styling across the theme so the single pill base fills with a cyan-to-magenta gradient on hover while the lettering gains a pulsing glow.

--- a/blocks/cta/style.css
+++ b/blocks/cta/style.css
@@ -41,11 +41,43 @@
 
 .wp-block-mccullough-digital-cta .wp-block-button__link,
 .wp-block-mccullough-digital-cta .cta-button {
-    background: var(--surface-dark);
+    position: relative;
+    overflow: hidden;
+    padding: 15px 42px;
+    border-radius: 999px;
+    background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta), var(--deep-purple));
     color: var(--text-primary);
-    border: 2px solid rgba(230, 241, 255, 0.18);
-    box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65);
-    transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease, border-color 0.35s ease;
+    border: 0;
+    box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65), 0 0 0 rgba(0, 229, 255, 0);
+    transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease;
+}
+
+.wp-block-mccullough-digital-cta .wp-block-button__link::before,
+.wp-block-mccullough-digital-cta .cta-button::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(120deg, rgba(0, 229, 255, 0.18), rgba(255, 0, 224, 0.22));
+    opacity: 0;
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 0.45s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.4s ease;
+    z-index: 0;
+}
+
+.wp-block-mccullough-digital-cta .wp-block-button__link::after,
+.wp-block-mccullough-digital-cta .cta-button::after {
+    content: '';
+    position: absolute;
+    inset: -18px;
+    border-radius: inherit;
+    background: radial-gradient(circle at 30% 20%, rgba(0, 229, 255, 0.45), transparent 60%),
+        radial-gradient(circle at 70% 80%, rgba(255, 0, 224, 0.4), transparent 65%);
+    opacity: 0;
+    transform: scale(0.85);
+    transition: opacity 0.45s ease, transform 0.45s ease;
+    z-index: -1;
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link:hover,
@@ -54,6 +86,21 @@
 .wp-block-mccullough-digital-cta .cta-button:focus-visible {
     transform: translateY(-4px) scale(1.03);
     color: var(--background-dark);
-    border-color: transparent;
     box-shadow: 0 18px 40px rgba(0, 229, 255, 0.35), 0 0 36px rgba(255, 0, 224, 0.3);
+}
+
+.wp-block-mccullough-digital-cta .wp-block-button__link:hover::before,
+.wp-block-mccullough-digital-cta .cta-button:hover::before,
+.wp-block-mccullough-digital-cta .wp-block-button__link:focus-visible::before,
+.wp-block-mccullough-digital-cta .cta-button:focus-visible::before {
+    opacity: 1;
+    transform: scaleX(1);
+}
+
+.wp-block-mccullough-digital-cta .wp-block-button__link:hover::after,
+.wp-block-mccullough-digital-cta .cta-button:hover::after,
+.wp-block-mccullough-digital-cta .wp-block-button__link:focus-visible::after,
+.wp-block-mccullough-digital-cta .cta-button:focus-visible::after {
+    opacity: 0.95;
+    transform: scale(1);
 }

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report now tracks the 2025-09-27 through 2025-10-03 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-08 Sweep
+1. **Front-End CTA Gradient Desync**
+   *Files:* `style.css`, `blocks/cta/style.css`, `standalone.html`
+   *Issue:* The home-page CTA buttons still rendered a dark pill with the gradient halo trapped underneath, so the hover flood and glow effects never appeared on the public site even though the editor preview was correct.
+   *Resolution:* Replaced the conic-gradient border trick with the editor's gradient flood treatment, added the matching halo animation, and updated the CTA block override plus standalone preview so every surface uses the same hover/focus transitions.
+
 ### 2025-10-07 Sweep
 1. **Navigation Contrast Request**
    *Files:* `style.css`

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.13 - 2025-10-08 =
+* **CTA Gradient Sync:** Matched the public CTA, hero, and read-more buttons with the editor flood-fill treatment so the cyan-to-magenta gradient, halo glow, and hover text swap animate identically across every surface.
+
  = 1.2.12 - 2025-10-07 =
 * **Navigation Palette Reset:** Kept primary menu links white at rest and removed the cyan sweep underline so the hover wobble now transitions into a neon-blue glow only when links are engaged.
 * **Hover-Fill CTA Pills:** Rebuilt CTA, hero, and read-more buttons to rest on a single dark pill that floods with a cyan-to-magenta gradient on hover while the lettering pulses and spaces out for extra flair.

--- a/standalone.html
+++ b/standalone.html
@@ -402,21 +402,6 @@
 
         /* --- CTA Button Styles --- */
 
-        @property --angle {
-          syntax: '<angle>';
-          initial-value: 0deg;
-          inherits: false;
-        }
-
-        @keyframes orbit {
-          0% {
-            --angle: 0deg;
-          }
-          100% {
-            --angle: 360deg;
-          }
-        }
-
         .cta-button,
         .wp-block-button__link.cta-button,
         .post-card .wp-block-read-more a {
@@ -426,12 +411,13 @@
             font-size: 1.2rem;
             color: var(--text-primary);
             text-decoration: none;
-            background: transparent; /* Changed */
-            border: 2px solid transparent; /* Changed */
+            background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta), var(--deep-purple));
+            border: 0;
             border-radius: 999px;
             position: relative;
-            transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease;
-            box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65);
+            overflow: hidden;
+            transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease, border-color 0.35s ease;
+            box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65), 0 0 0 rgba(0, 229, 255, 0);
             letter-spacing: 0.02em;
             isolation: isolate;
             display: inline-flex;
@@ -444,21 +430,14 @@
         .post-card .wp-block-read-more a::before {
             content: '';
             position: absolute;
-            inset: -2px; /* Control border thickness */
+            inset: 0;
             border-radius: inherit;
-            background: conic-gradient(
-                from var(--angle),
-                transparent 0%,
-                transparent 20%,
-                var(--neon-cyan),
-                var(--neon-magenta),
-                transparent 80%,
-                transparent 100%
-            );
-            z-index: -2;
-            animation: orbit 4s linear infinite;
-            transition: opacity 0.4s ease;
-            opacity: 0.8;
+            background: linear-gradient(120deg, rgba(0, 229, 255, 0.18), rgba(255, 0, 224, 0.22));
+            opacity: 0;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.45s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.4s ease;
+            z-index: 0;
         }
 
         .cta-button::after,
@@ -466,9 +445,13 @@
         .post-card .wp-block-read-more a::after {
             content: '';
             position: absolute;
-            inset: 0;
+            inset: -18px;
             border-radius: inherit;
-            background: var(--surface-dark);
+            background: radial-gradient(circle at 30% 20%, rgba(0, 229, 255, 0.45), transparent 60%),
+                radial-gradient(circle at 70% 80%, rgba(255, 0, 224, 0.4), transparent 65%);
+            opacity: 0;
+            transform: scale(0.85);
+            transition: opacity 0.45s ease, transform 0.45s ease;
             z-index: -1;
         }
 
@@ -487,7 +470,8 @@
         .post-card .wp-block-read-more a:hover,
         .post-card .wp-block-read-more a:focus-visible {
             transform: translateY(-4px) scale(1.03);
-            box-shadow: 0 18px 40px rgba(0, 229, 255, 0.25), 0 0 36px rgba(255, 0, 224, 0.2);
+            color: var(--background-dark);
+            box-shadow: 0 18px 40px rgba(0, 229, 255, 0.35), 0 0 36px rgba(255, 0, 224, 0.3);
         }
 
         .cta-button:hover::before,
@@ -496,8 +480,8 @@
         .wp-block-button__link.cta-button:focus-visible::before,
         .post-card .wp-block-read-more a:hover::before,
         .post-card .wp-block-read-more a:focus-visible::before {
-            animation-duration: 2s; /* Speed up animation on hover */
             opacity: 1;
+            transform: scaleX(1);
         }
 
         .cta-button:hover .btn-text,
@@ -507,9 +491,18 @@
         .post-card .wp-block-read-more a:hover .btn-text,
         .post-card .wp-block-read-more a:focus-visible .btn-text {
             letter-spacing: 0.1em;
-            color: var(--neon-cyan);
-            text-shadow: 0 0 12px rgba(0, 229, 255, 0.7), 0 0 24px rgba(0, 229, 255, 0.55);
-            animation: glyph-glow 1.6s ease-in-out infinite alternate;
+            color: var(--background-dark);
+            text-shadow: 0 0 12px rgba(0, 229, 255, 0.4), 0 0 24px rgba(255, 0, 224, 0.35);
+        }
+
+        .cta-button:hover::after,
+        .cta-button:focus-visible::after,
+        .wp-block-button__link.cta-button:hover::after,
+        .wp-block-button__link.cta-button:focus-visible::after,
+        .post-card .wp-block-read-more a:hover::after,
+        .post-card .wp-block-read-more a:focus-visible::after {
+            opacity: 0.95;
+            transform: scale(1);
         }
 
         .cta-button:focus-visible,
@@ -530,6 +523,12 @@
         .cta-button.is-static::before,
         .wp-block-button__link.cta-button.is-static::before,
         .post-card .wp-block-read-more a.is-static::before {
+            display: none;
+        }
+
+        .cta-button.is-static::after,
+        .wp-block-button__link.cta-button.is-static::after,
+        .post-card .wp-block-read-more a.is-static::after {
             display: none;
         }
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.12
+Version:       1.2.13
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital
@@ -265,21 +265,6 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 
 /* --- CTA Button Styles --- */
 
-@property --angle {
-  syntax: '<angle>';
-  initial-value: 0deg;
-  inherits: false;
-}
-
-@keyframes orbit {
-  0% {
-    --angle: 0deg;
-  }
-  100% {
-    --angle: 360deg;
-  }
-}
-
 .cta-button,
 .wp-block-button__link.cta-button,
 .post-card .wp-block-read-more a {
@@ -289,12 +274,13 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     font-size: 1.2rem;
     color: var(--text-primary);
     text-decoration: none;
-    background: transparent; /* Changed */
-    border: 2px solid transparent; /* Changed */
+    background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta), var(--deep-purple));
+    border: 0;
     border-radius: 999px;
     position: relative;
-    transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease;
-    box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65);
+    overflow: hidden;
+    transition: transform 0.35s ease, box-shadow 0.35s ease, color 0.35s ease, border-color 0.35s ease;
+    box-shadow: 0 12px 30px rgba(3, 6, 14, 0.65), 0 0 0 rgba(0, 229, 255, 0);
     letter-spacing: 0.02em;
     isolation: isolate;
     display: inline-flex;
@@ -307,21 +293,14 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .post-card .wp-block-read-more a::before {
     content: '';
     position: absolute;
-    inset: -2px; /* Control border thickness */
+    inset: 0;
     border-radius: inherit;
-    background: conic-gradient(
-        from var(--angle),
-        transparent 0%,
-        transparent 20%,
-        var(--neon-cyan),
-        var(--neon-magenta),
-        transparent 80%,
-        transparent 100%
-    );
-    z-index: -2;
-    animation: orbit 4s linear infinite;
-    transition: opacity 0.4s ease;
-    opacity: 0.8;
+    background: linear-gradient(120deg, rgba(0, 229, 255, 0.18), rgba(255, 0, 224, 0.22));
+    opacity: 0;
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 0.45s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.4s ease;
+    z-index: 0;
 }
 
 .cta-button::after,
@@ -329,9 +308,13 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .post-card .wp-block-read-more a::after {
     content: '';
     position: absolute;
-    inset: 0;
+    inset: -18px;
     border-radius: inherit;
-    background: var(--surface-dark);
+    background: radial-gradient(circle at 30% 20%, rgba(0, 229, 255, 0.45), transparent 60%),
+        radial-gradient(circle at 70% 80%, rgba(255, 0, 224, 0.4), transparent 65%);
+    opacity: 0;
+    transform: scale(0.85);
+    transition: opacity 0.45s ease, transform 0.45s ease;
     z-index: -1;
 }
 
@@ -350,7 +333,8 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .post-card .wp-block-read-more a:hover,
 .post-card .wp-block-read-more a:focus-visible {
     transform: translateY(-4px) scale(1.03);
-    box-shadow: 0 18px 40px rgba(0, 229, 255, 0.25), 0 0 36px rgba(255, 0, 224, 0.2);
+    color: var(--background-dark);
+    box-shadow: 0 18px 40px rgba(0, 229, 255, 0.35), 0 0 36px rgba(255, 0, 224, 0.3);
 }
 
 .cta-button:hover::before,
@@ -359,8 +343,8 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .wp-block-button__link.cta-button:focus-visible::before,
 .post-card .wp-block-read-more a:hover::before,
 .post-card .wp-block-read-more a:focus-visible::before {
-    animation-duration: 2s; /* Speed up animation on hover */
     opacity: 1;
+    transform: scaleX(1);
 }
 
 .cta-button:hover .btn-text,
@@ -370,9 +354,18 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .post-card .wp-block-read-more a:hover .btn-text,
 .post-card .wp-block-read-more a:focus-visible .btn-text {
     letter-spacing: 0.1em;
-    color: var(--neon-cyan);
-    text-shadow: 0 0 12px rgba(0, 229, 255, 0.7), 0 0 24px rgba(0, 229, 255, 0.55);
-    animation: glyph-glow 1.6s ease-in-out infinite alternate;
+    color: var(--background-dark);
+    text-shadow: 0 0 12px rgba(0, 229, 255, 0.4), 0 0 24px rgba(255, 0, 224, 0.35);
+}
+
+.cta-button:hover::after,
+.cta-button:focus-visible::after,
+.wp-block-button__link.cta-button:hover::after,
+.wp-block-button__link.cta-button:focus-visible::after,
+.post-card .wp-block-read-more a:hover::after,
+.post-card .wp-block-read-more a:focus-visible::after {
+    opacity: 0.95;
+    transform: scale(1);
 }
 
 .cta-button:focus-visible,
@@ -393,6 +386,12 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 .cta-button.is-static::before,
 .wp-block-button__link.cta-button.is-static::before,
 .post-card .wp-block-read-more a.is-static::before {
+    display: none;
+}
+
+.cta-button.is-static::after,
+.wp-block-button__link.cta-button.is-static::after,
+.post-card .wp-block-read-more a.is-static::after {
     display: none;
 }
 
@@ -430,10 +429,16 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     .cta-button:hover .btn-text,
     .cta-button:focus-visible .btn-text,
     .wp-block-button__link.cta-button:hover .btn-text,
-    .wp-block-button__link.cta-button:focus-visible .btn-text,
-    .post-card .wp-block-read-more a:hover .btn-text,
-    .post-card .wp-block-read-more a:focus-visible .btn-text {
+.wp-block-button__link.cta-button:focus-visible .btn-text,
+.post-card .wp-block-read-more a:hover .btn-text,
+.post-card .wp-block-read-more a:focus-visible .btn-text {
         animation: none;
+    }
+
+    .cta-button::after,
+    .wp-block-button__link.cta-button::after,
+    .post-card .wp-block-read-more a::after {
+        transition: opacity 0.45s ease;
     }
 
     .stars,


### PR DESCRIPTION
## Summary
- align the public CTA, hero, and read-more buttons with the editor’s gradient flood/halo animation
- refresh the CTA block styling and standalone preview to share the same hover/focus transitions
- document the fix in AGENTS.md, bug-report.md, readme.txt, and bump the theme version to 1.2.13

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8ecf91bf4832486ead0b1709dd264