### PR TITLE
Restore header hover accent underline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-09):**
+    - Restored the transparent header border baseline so the neon hover underline returns without reintroducing a visible divider at rest in both the theme CSS and standalone preview.
 - **Latest (2025-10-08):**
     - Synced the front-end CTA, hero, and read more buttons with the editor treatment so the gradient flood, halo glow, and hover color swap all animate identically across the theme, block styles, and standalone preview.
 - **Latest (2025-10-07):**

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report now tracks the 2025-09-27 through 2025-10-03 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-09 Sweep
+1. **Header Hover Highlight Missing**
+   *Files:* `style.css`, `standalone.html`
+   *Issue:* Removing the static header divider also stripped the transparent base border, so the neon cyan accent never appeared on hover because there was no border to recolor.
+   *Resolution:* Restored the header border as a transparent baseline and kept the hover state swapping the color, preserving the clean resting state while allowing the requested neon underline to return.
+
 ### 2025-10-08 Sweep
 1. **Front-End CTA Gradient Desync**
    *Files:* `style.css`, `blocks/cta/style.css`, `standalone.html`

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.14 - 2025-10-09 =
+* **Header Hover Highlight:** Reintroduced the transparent baseline border on the fixed header so the neon cyan underline and hover glow animate as intended without showing a divider at rest.
+
 = 1.2.13 - 2025-10-08 =
 * **CTA Gradient Sync:** Matched the public CTA, hero, and read-more buttons with the editor flood-fill treatment so the cyan-to-magenta gradient, halo glow, and hover text swap animate identically across every surface.
 

--- a/standalone.html
+++ b/standalone.html
@@ -141,7 +141,7 @@
             transition: transform .4s cubic-bezier(.22,.61,.36,1), background-color 0.3s ease;
             background: rgba(0,0,0,0.8);
             backdrop-filter: blur(10px);
-            border-bottom: 2px solid #222;
+            border-bottom: 2px solid transparent;
             overflow: hidden; /* Hides the pseudo-element when it's outside */
         }
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.13
+Version:       1.2.14
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital
@@ -144,6 +144,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     transition: transform .4s cubic-bezier(.22,.61,.36,1), background-color 0.3s ease;
     background: rgba(0,0,0,0.8);
     backdrop-filter: blur(10px);
+    border-bottom: 2px solid transparent;
     overflow: hidden; /* Hides the pseudo-element when it's outside */
 }
 


### PR DESCRIPTION
## Summary
- restore the fixed header's transparent baseline border so the neon hover underline reappears without a resting divider
- mirror the styling update in the standalone preview and document the fix across agent notes, bug report, and changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daac948db08324a17240f8923c7554