### PR TITLE
Rebuild footer CTA and intensify the starfield

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-10):**
+    - Intensified the footer starfield with layered parallax drift and brightness pulses that respect `prefers-reduced-motion` while keeping the neon skyline alive.
+    - Freed the footer logo from the header lock and rebuilt the footer into a CTA-led, neon-accented grid that mirrors the hero's typography and gradients.
 - **Latest (2025-10-09):**
     - Restored the transparent header border baseline so the neon hover underline returns without reintroducing a visible divider at rest in both the theme CSS and standalone preview.
 - **Latest (2025-10-08):**

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,22 @@ This report now tracks the 2025-09-27 through 2025-10-03 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-10 Sweep
+1. **Footer Starfield Felt Static**
+   *Files:* `style.css`
+   *Issue:* The footer's star layers only drifted slowly on long loops, so there was no parallax or brightness variation to make the twinkle visible.
+   *Resolution:* Replaced the single `move-stars` loop with layered drift/twinkle animations at staggered speeds and delays, added blend/blur treatments per layer, and ensured the motion disables cleanly for reduced-motion users.
+
+2. **Footer Logo Was Still Squished**
+   *Files:* `style.css`
+   *Issue:* The global `.custom-logo` height locked the footer mark to the header's 60px cap, so the footer override never gained enough height to respect the logo's aspect ratio.
+   *Resolution:* Introduced shared logo size variables, reset the footer logo to `height: auto` with a dedicated max height, and preserved the header sizing via the new `--logo-size-header` token.
+
+3. **Footer Layout Didn’t Match the Hero Vibe**
+   *Files:* `parts/footer.html`, `style.css`, `editor-style.css`
+   *Issue:* The footer stacked a logo, title, and social icons with minimal styling, lacking the neon gradients, CTA energy, and typography established by the hero/header.
+   *Resolution:* Rebuilt the footer into a CTA-first grid with glowing dividers, Caveat headlines, quick-link and contact panels, and mirrored the styling in the editor preview so the closing section carries the hero’s neon tone.
+
 ### 2025-10-09 Sweep
 1. **Header Hover Highlight Missing**
    *Files:* `style.css`, `standalone.html`

--- a/editor-style.css
+++ b/editor-style.css
@@ -11,6 +11,9 @@
     --surface-border: var(--wp--preset--color--surface-border, #1d2330);
     --text-primary: #e6f1ff;
     --text-secondary: #c5d8f2;
+
+    --logo-size-header: clamp(56px, 6vw, 68px);
+    --logo-size-footer: clamp(96px, 14vw, 140px);
 }
 
 .editor-styles-wrapper {
@@ -203,6 +206,179 @@
     background: var(--neon-cyan);
     border-radius: 2px;
     box-shadow: 0 0 5px var(--neon-cyan), 0 0 10px var(--neon-cyan), 0 0 20px var(--neon-cyan);
+}
+
+/* Footer Preview */
+.editor-styles-wrapper .footer-container {
+    max-width: min(1200px, 92vw);
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(40px, 6vw, 72px);
+    position: relative;
+    align-items: stretch;
+}
+
+.editor-styles-wrapper .footer-cta {
+    position: relative;
+    padding: clamp(32px, 5vw, 56px);
+    border-radius: 32px;
+    background:
+        radial-gradient(circle at 12% 18%, rgba(0, 229, 255, 0.32), transparent 62%),
+        radial-gradient(circle at 82% 24%, rgba(255, 0, 224, 0.26), transparent 60%),
+        rgba(10, 13, 22, 0.92);
+    border: 1px solid rgba(0, 229, 255, 0.22);
+    box-shadow: 0 25px 70px rgba(0, 229, 255, 0.18), 0 35px 90px rgba(255, 0, 224, 0.14);
+    text-align: center;
+    overflow: hidden;
+}
+
+.editor-styles-wrapper .footer-cta::before {
+    content: '';
+    position: absolute;
+    inset: -15%;
+    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 65%);
+    filter: blur(55px);
+    opacity: 0.55;
+    z-index: 0;
+}
+
+.editor-styles-wrapper .footer-cta > * {
+    position: relative;
+    z-index: 1;
+}
+
+.editor-styles-wrapper .footer-cta__title {
+    font-family: 'Caveat', cursive;
+    font-size: clamp(2.75rem, 8vw, 4.75rem);
+    color: var(--text-primary);
+    margin: 0 0 10px;
+    text-shadow: 0 0 16px rgba(0, 229, 255, 0.45), 0 0 24px rgba(255, 0, 224, 0.35);
+}
+
+.editor-styles-wrapper .footer-cta__description {
+    font-size: clamp(1rem, 2.6vw, 1.3rem);
+    color: var(--text-secondary);
+    margin: 0 0 clamp(20px, 4vw, 32px);
+    max-width: 620px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.editor-styles-wrapper .footer-cta__buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    justify-content: center;
+}
+
+.editor-styles-wrapper .footer-cta__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--neon-cyan);
+    font-weight: 700;
+    text-decoration: none;
+    padding: 14px 26px;
+    border-radius: 999px;
+    border: 1px solid rgba(0, 229, 255, 0.36);
+    background: rgba(9, 13, 21, 0.65);
+}
+
+.editor-styles-wrapper .footer-cta__link,
+.editor-styles-wrapper .footer-nav a,
+.editor-styles-wrapper .footer-contact a {
+    outline-offset: 4px;
+}
+
+.editor-styles-wrapper .footer-divider {
+    height: 1px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.7), rgba(255, 0, 224, 0.6), transparent);
+    opacity: 0.65;
+}
+
+.editor-styles-wrapper .footer-core {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(24px, 5vw, 48px);
+    align-items: start;
+}
+
+.editor-styles-wrapper .footer-branding,
+.editor-styles-wrapper .footer-links,
+.editor-styles-wrapper .footer-social,
+.editor-styles-wrapper .footer-contact {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.editor-styles-wrapper .footer-branding .wp-block-site-logo {
+    display: flex;
+    justify-content: flex-start;
+}
+
+.editor-styles-wrapper .footer-branding .custom-logo {
+    height: auto;
+    width: auto;
+    max-height: var(--logo-size-footer);
+}
+
+.editor-styles-wrapper .footer-branding .wp-block-site-title {
+    font-family: 'Caveat', cursive;
+    font-size: clamp(2.2rem, 6vw, 3.2rem);
+    color: var(--text-primary);
+    margin: 0;
+    text-shadow: 0 0 12px rgba(0, 229, 255, 0.4);
+}
+
+.editor-styles-wrapper .footer-tagline {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    margin: 0;
+    max-width: 320px;
+}
+
+.editor-styles-wrapper .footer-section-title {
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.85rem;
+    color: rgba(230, 241, 255, 0.65);
+    margin: 0 0 4px;
+}
+
+.editor-styles-wrapper .footer-nav {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.editor-styles-wrapper .footer-nav a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.editor-styles-wrapper .social-links-menu {
+    gap: 18px;
+}
+
+.editor-styles-wrapper .footer-contact a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.editor-styles-wrapper .site-info {
+    font-size: 0.9em;
+    text-align: center;
+    color: rgba(197, 216, 242, 0.8);
 }
 
 .editor-styles-wrapper .services-grid {

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -14,17 +14,67 @@
 
 <!-- wp:group {"className":"footer-container","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group footer-container">
-<!-- wp:group {"className":"footer-branding","layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
+<!-- wp:group {"className":"footer-cta","layout":{"type":"constrained"}} -->
+<div class="wp-block-group footer-cta">
+<!-- wp:heading {"level":2,"className":"footer-cta__title"} -->
+<h2 class="footer-cta__title">Ready to build your next luminous launch?</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"className":"footer-cta__description"} -->
+<p class="footer-cta__description">From bold strategy to neon-soaked visuals, we craft digital experiences that glow across every screen. Let&#8217;s make something unforgettable together.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"className":"footer-cta__buttons"} -->
+<div class="wp-block-buttons footer-cta__buttons">
+<!-- wp:button {"className":"cta-button"} -->
+<div class="wp-block-button cta-button"><a class="wp-block-button__link cta-button" href="/contact"><span class="btn-text">Start a Project</span></a></div>
+<!-- /wp:button -->
+
+<!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link footer-cta__link" href="/portfolio">View Our Work</a></div>
+<!-- /wp:button -->
+</div>
+<!-- /wp:buttons -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"className":"footer-divider","layout":{"type":"constrained"}} -->
+<div class="wp-block-group footer-divider" aria-hidden="true"></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"className":"footer-core","layout":{"type":"grid"}} -->
+<div class="wp-block-group footer-core">
+<!-- wp:group {"className":"footer-branding","layout":{"type":"flex","orientation":"vertical","justifyContent":"flex-start"}} -->
 <div class="wp-block-group footer-branding">
 <!-- wp:site-logo /-->
 
 <!-- wp:site-title {"level":2,"isLink":false} /-->
+
+<!-- wp:paragraph {"className":"footer-tagline"} -->
+<p class="footer-tagline">Digital experiences with a neon soul—crafted in Columbus and deployed worldwide.</p>
+<!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"className":"footer-social","layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:group {"className":"footer-links","layout":{"type":"flex","orientation":"vertical","justifyContent":"flex-start"}} -->
+<div class="wp-block-group footer-links">
+<!-- wp:paragraph {"className":"footer-section-title"} -->
+<p class="footer-section-title">Quick Links</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list {"className":"footer-nav"} -->
+<ul class="footer-nav"><li><a href="/services">Services</a></li><li><a href="/about">About</a></li><li><a href="/journal">Journal</a></li><li><a href="/contact">Contact</a></li></ul>
+<!-- /wp:list -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"className":"footer-social","layout":{"type":"flex","orientation":"vertical","justifyContent":"flex-start"}} -->
 <div class="wp-block-group footer-social">
-<!-- wp:social-links {"className":"social-links-menu","layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:paragraph {"className":"footer-section-title"} -->
+<p class="footer-section-title">Follow</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:social-links {"className":"social-links-menu","layout":{"type":"flex","justifyContent":"flex-start"}} -->
 <ul class="wp-block-social-links social-links-menu">
 <!-- wp:social-link {"url":"https://www.facebook.com/mcculloughdigital","service":"facebook"} /-->
 
@@ -36,10 +86,28 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"className":"site-info","layout":{"type":"constrained"}} -->
-<div class="wp-block-group site-info">
+<!-- wp:group {"className":"footer-contact","layout":{"type":"flex","orientation":"vertical","justifyContent":"flex-start"}} -->
+<div class="wp-block-group footer-contact">
+<!-- wp:paragraph {"className":"footer-section-title"} -->
+<p class="footer-section-title">Say hello</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="mailto:hello@mccullough.digital">hello@mccullough.digital</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="/contact">Book a discovery call →</a></p>
+<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"className":"site-info footer-legal","layout":{"type":"constrained"}} -->
+<div class="wp-block-group site-info footer-legal">
 <!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">&copy; 2024 McCullough Digital. All Rights Reserved. Let&#8217;s build the future.</p>
+<p class="has-text-align-center">&copy; 2025 McCullough Digital. Crafted with heart, strategy, and a dash of neon.</p>
 <!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,10 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.15 - 2025-10-10 =
+* **Footer Glow-Up:** Rebuilt the footer into a CTA-led neon grid with Caveat headlines, quick links, and contact details so the closing section mirrors the hero/header energy on both the front end and in the Site Editor.
+* **Starfield Twinkle:** Layered faster parallax drift and brightness pulses across the footer starfield while adding motion-reduction fallbacks and freeing the footer logo to scale via new shared size tokens.
+
 = 1.2.14 - 2025-10-09 =
 * **Header Hover Highlight:** Reintroduced the transparent baseline border on the fixed header so the neon cyan underline and hover glow animate as intended without showing a divider at rest.
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.14
+Version:       1.2.15
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital
@@ -30,6 +30,9 @@ Text Domain:   mccullough-digital
     --z-index-content: 2;
     --z-index-header: 1000;
     --z-index-modal: 1001;
+
+    --logo-size-header: clamp(56px, 6vw, 68px);
+    --logo-size-footer: clamp(96px, 14vw, 140px);
 }
 
 /* --- Base reset --- */
@@ -189,7 +192,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 }
 
 .custom-logo {
-    height: 60px; /* Adjust as needed */
+    height: var(--logo-size-header);
     width: auto;
     display: block;
     transition: all 0.3s ease;
@@ -396,9 +399,53 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     display: none;
 }
 
-@keyframes move-stars {
+@keyframes star-drift-slow {
     from { background-position: 0 0; }
-    to   { background-position: 0 -2000px; }
+    to   { background-position: -2200px 1600px; }
+}
+
+@keyframes star-drift-medium {
+    from { background-position: 0 0; }
+    to   { background-position: 2000px -2000px; }
+}
+
+@keyframes star-drift-fast {
+    from { background-position: 0 0; }
+    to   { background-position: -2400px -2000px; }
+}
+
+@keyframes star-twinkle-soft {
+    0%, 100% {
+        opacity: 0.35;
+        filter: brightness(0.8);
+    }
+    40% {
+        opacity: 0.75;
+        filter: brightness(1.25);
+    }
+    70% {
+        opacity: 0.55;
+        filter: brightness(1);
+    }
+}
+
+@keyframes star-twinkle-bold {
+    0%, 100% {
+        opacity: 0.45;
+        filter: brightness(0.85);
+    }
+    25% {
+        opacity: 0.85;
+        filter: brightness(1.4);
+    }
+    55% {
+        opacity: 0.6;
+        filter: brightness(1.1);
+    }
+    82% {
+        opacity: 0.95;
+        filter: brightness(1.55);
+    }
 }
 
 @keyframes glyph-glow {
@@ -446,6 +493,8 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     .stars2,
     .stars3 {
         animation: none;
+        opacity: 0.5;
+        filter: none;
     }
 }
 
@@ -462,15 +511,14 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 /* Starfield Background */
 .stars, .stars2, .stars3 {
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset: 0;
     width: 100%;
     height: 100%;
     display: block;
     pointer-events: none;
-    z-index: var(--z-index-default);
+    z-index: var(--z-index-background);
+    background-position: 0 0;
+    will-change: background-position, opacity, filter;
 }
 
 .stars .wp-block-group__inner-container,
@@ -485,37 +533,155 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 
 .stars {
     background: transparent url('./assets/stars.svg') repeat;
-    background-size: 2000px 2000px;
-    animation: move-stars 200s linear infinite;
+    background-size: 2200px 2200px;
+    opacity: 0.4;
+    animation: star-drift-slow 90s linear infinite, star-twinkle-soft 7s ease-in-out infinite;
 }
 
 .stars2 {
     background: transparent url('./assets/stars2.svg') repeat;
     background-size: 2000px 2000px;
-    animation: move-stars 150s linear infinite;
+    opacity: 0.55;
+    mix-blend-mode: screen;
+    filter: blur(0.4px);
+    animation: star-drift-medium 75s linear infinite, star-twinkle-bold 5.5s ease-in-out infinite;
+    animation-delay: 0s, 1.2s;
 }
 
 .stars3 {
     background: transparent url('./assets/stars3.svg') repeat;
-    background-size: 2000px 2000px;
-    animation: move-stars 100s linear infinite;
+    background-size: 2400px 2400px;
+    opacity: 0.75;
+    filter: drop-shadow(0 0 6px rgba(0, 229, 255, 0.25));
+    animation: star-drift-fast 60s linear infinite, star-twinkle-bold 4.2s ease-in-out infinite;
+    animation-delay: 0s, 2.1s;
 }
 
 .footer-container {
-    max-width: 1200px;
+    max-width: min(1200px, 92vw);
     margin: 0 auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
+    gap: clamp(40px, 6vw, 72px);
     position: relative;
     z-index: var(--z-index-content);
+    align-items: stretch;
+}
+
+.footer-cta {
+    position: relative;
+    padding: clamp(32px, 5vw, 56px);
+    border-radius: 32px;
+    background:
+        radial-gradient(circle at 12% 18%, rgba(0, 229, 255, 0.32), transparent 62%),
+        radial-gradient(circle at 82% 24%, rgba(255, 0, 224, 0.26), transparent 60%),
+        rgba(10, 13, 22, 0.92);
+    border: 1px solid rgba(0, 229, 255, 0.22);
+    box-shadow: 0 25px 70px rgba(0, 229, 255, 0.18), 0 35px 90px rgba(255, 0, 224, 0.14);
+    overflow: hidden;
+    text-align: center;
+}
+
+.footer-cta::before {
+    content: '';
+    position: absolute;
+    inset: -15%;
+    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 65%);
+    filter: blur(55px);
+    opacity: 0.55;
+    z-index: 0;
+}
+
+.footer-cta > * {
+    position: relative;
+    z-index: 1;
+}
+
+.footer-cta__title {
+    font-family: 'Caveat', cursive;
+    font-size: clamp(2.75rem, 8vw, 4.75rem);
+    color: var(--text-primary);
+    margin: 0 0 10px;
+    text-shadow: 0 0 16px rgba(0, 229, 255, 0.45), 0 0 24px rgba(255, 0, 224, 0.35);
+}
+
+.footer-cta__description {
+    font-size: clamp(1rem, 2.6vw, 1.3rem);
+    color: var(--text-secondary);
+    margin: 0 0 clamp(20px, 4vw, 32px);
+    max-width: 620px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.footer-cta__buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    justify-content: center;
+}
+
+.footer-cta__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--neon-cyan);
+    font-weight: 700;
+    text-decoration: none;
+    padding: 14px 26px;
+    border-radius: 999px;
+    border: 1px solid rgba(0, 229, 255, 0.36);
+    background: rgba(9, 13, 21, 0.65);
+    transition: color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.footer-cta__link:hover,
+.footer-cta__link:focus-visible {
+    color: var(--background-dark);
+    border-color: transparent;
+    transform: translateY(-3px);
+    box-shadow: 0 14px 40px rgba(0, 229, 255, 0.25);
+    background: linear-gradient(120deg, rgba(0, 229, 255, 0.95), rgba(255, 0, 224, 0.9));
+}
+
+.footer-cta__link:focus-visible,
+.footer-nav a:focus-visible,
+.footer-contact a:focus-visible {
+    outline: 2px solid var(--neon-cyan);
+    outline-offset: 4px;
+}
+
+.footer-divider {
+    height: 1px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.7), rgba(255, 0, 224, 0.6), transparent);
+    opacity: 0.65;
+}
+
+.footer-core {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: clamp(24px, 5vw, 48px);
+    align-items: start;
+}
+
+.footer-branding {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.footer-links {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
 }
 
 .footer-branding .wp-block-site-logo {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
 }
 
 .footer-branding .custom-logo-link {
@@ -526,42 +692,136 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 }
 
 .footer-branding .custom-logo {
-    max-height: 70px;
-    margin-bottom: 20px;
+    height: auto;
+    width: auto;
+    max-height: var(--logo-size-footer);
+    margin-bottom: 0;
     filter: drop-shadow(0 0 8px rgba(0, 229, 255, 0.6));
     transition: filter 0.3s ease;
 }
 
 .footer-branding .custom-logo-link:hover .custom-logo,
 .footer-branding .custom-logo-link:focus-visible .custom-logo {
-    filter: drop-shadow(0 0 15px var(--neon-cyan)) drop-shadow(0 0 5px rgba(255, 0, 224, 0.45));
+    filter: drop-shadow(0 0 20px rgba(0, 229, 255, 0.8)) drop-shadow(0 0 10px rgba(255, 0, 224, 0.55));
+}
+
+.footer-branding .wp-block-site-title {
+    font-family: 'Caveat', cursive;
+    font-size: clamp(2.2rem, 6vw, 3.2rem);
+    color: var(--text-primary);
+    margin: 0;
+    text-shadow: 0 0 12px rgba(0, 229, 255, 0.4);
+}
+
+.footer-tagline {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    margin: 0;
+    max-width: 320px;
+}
+
+.footer-nav {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.footer-nav a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 600;
+    position: relative;
+    transition: color 0.25s ease, text-shadow 0.25s ease;
+}
+
+.footer-nav a::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -4px;
+    width: 0;
+    height: 2px;
+    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+    transition: width 0.25s ease;
+    box-shadow: 0 0 6px rgba(0, 229, 255, 0.55);
+}
+
+.footer-nav a:hover,
+.footer-nav a:focus-visible {
+    color: var(--text-primary);
+    text-shadow: 0 0 10px rgba(0, 229, 255, 0.55);
+}
+
+.footer-nav a:hover::after,
+.footer-nav a:focus-visible::after {
+    width: 100%;
+}
+
+.footer-section-title {
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.85rem;
+    color: rgba(230, 241, 255, 0.65);
+    margin: 0 0 16px;
+}
+
+.footer-social {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
 }
 
 .social-links-menu {
     list-style: none;
     padding: 0;
-    margin: 20px 0;
+    margin: 0;
     display: flex;
-    gap: 25px;
-    justify-content: center;
+    gap: 18px;
 }
 
 .wp-social-link svg {
     height: 28px;
     width: 28px;
     fill: var(--text-secondary);
-    transition: all 0.3s ease;
+    transition: transform 0.3s ease, filter 0.3s ease, fill 0.3s ease;
 }
 
-.wp-social-link:hover svg {
+.wp-social-link:hover svg,
+.wp-social-link:focus-visible svg {
     fill: var(--neon-cyan);
-    transform: scale(1.1) translateY(-3px);
-    filter: drop-shadow(0 0 8px var(--neon-cyan));
+    transform: translateY(-4px) scale(1.1);
+    filter: drop-shadow(0 0 10px rgba(0, 229, 255, 0.8));
+}
+
+.footer-contact {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.footer-contact a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 600;
+    transition: color 0.25s ease, text-shadow 0.25s ease;
+}
+
+.footer-contact a:hover,
+.footer-contact a:focus-visible {
+    color: var(--neon-cyan);
+    text-shadow: 0 0 10px rgba(0, 229, 255, 0.45);
 }
 
 .site-info {
     font-size: 0.9em;
-    margin-top: 20px;
+    text-align: center;
+    color: rgba(197, 216, 242, 0.8);
 }
 
 
@@ -672,6 +932,35 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     .main-navigation.wp-block-navigation .wp-block-navigation__responsive-container-close::after {
         top: 50%;
         transform: translateY(-50%) rotate(-45deg);
+    }
+
+    .footer-container {
+        align-items: center;
+        text-align: center;
+        gap: 48px;
+    }
+
+    .footer-core {
+        grid-template-columns: 1fr;
+        justify-items: center;
+    }
+
+    .footer-branding,
+    .footer-social,
+    .footer-contact {
+        align-items: center;
+    }
+
+    .footer-links {
+        align-items: center;
+    }
+
+    .footer-branding .wp-block-site-logo {
+        justify-content: center;
+    }
+
+    .footer-nav {
+        align-items: center;
     }
 }
 


### PR DESCRIPTION
## Summary
- layer faster parallax drift and twinkle animations across the footer starfield while honoring reduced-motion preferences
- free the footer logo from the header size lock and add neon CTA/contact grid styling in both front-end and editor styles
- document the update in the changelog, bug report, and agent notes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab26f26288324adb5fa84509993e3