### PR TITLE
Restyle footer without CTA card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-12):**
+    - Replaced the standalone footer CTA card with a gradient-wrapped shell that keeps the neon glow, centres the headline/description, and tightens spacing so the legal line no longer floats above a vast black void.
 - **Latest (2025-10-11):**
     - Renamed the neon footer template part to `footer-neon` and updated every template plus the PHP fallback so installs bypass stale Site Editor overrides and immediately load the rebuilt CTA grid.
     - Registered the header and neon footer template parts in `theme.json` for clearer organisation inside the Site Editor.

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report now tracks the 2025-09-27 through 2025-10-11 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-12 Sweep
+1. **Footer CTA Card Stuck Above Site Info**
+   *Files:* `parts/footer-neon.html`, `style.css`, `editor-style.css`
+   *Issue:* The neon footer always rendered a standalone CTA card with duplicate copy and buttons the client no longer wanted, and the surrounding layout left an oversized block of empty space beneath the legal text.
+   *Resolution:* Removed the CTA block, rebuilt the footer template around a single gradient "shell" that carries the neon glow into the core columns, added a compact headline/description treatment, and tightened spacing so the footer collapses cleanly without the unwanted black void.
+
 ### 2025-10-11 Sweep
 1. **Neon Footer Still Showing Legacy Layout**
    *Files:* `parts/footer-neon.html`, `templates/404.html`, `templates/archive.html`, `templates/front-page.html`, `templates/home-landing.html`, `templates/index.html`, `templates/page-wide.html`, `templates/search.html`, `templates/singular.html`, `index.php`, `theme.json`

--- a/editor-style.css
+++ b/editor-style.css
@@ -214,81 +214,79 @@
     margin: 0 auto;
     display: flex;
     flex-direction: column;
-    gap: clamp(40px, 6vw, 72px);
+    gap: clamp(32px, 5vw, 60px);
     position: relative;
     align-items: stretch;
 }
 
-.editor-styles-wrapper .footer-cta {
+.editor-styles-wrapper .footer-shell {
     position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(28px, 4.5vw, 48px);
     padding: clamp(32px, 5vw, 56px);
-    border-radius: 32px;
+    border-radius: 36px;
     background:
-        radial-gradient(circle at 12% 18%, rgba(0, 229, 255, 0.32), transparent 62%),
-        radial-gradient(circle at 82% 24%, rgba(255, 0, 224, 0.26), transparent 60%),
-        rgba(10, 13, 22, 0.92);
-    border: 1px solid rgba(0, 229, 255, 0.22);
-    box-shadow: 0 25px 70px rgba(0, 229, 255, 0.18), 0 35px 90px rgba(255, 0, 224, 0.14);
-    text-align: center;
+        radial-gradient(circle at 10% 18%, rgba(0, 229, 255, 0.3), transparent 60%),
+        radial-gradient(circle at 85% 20%, rgba(255, 0, 224, 0.24), transparent 58%),
+        linear-gradient(160deg, rgba(8, 12, 22, 0.9), rgba(8, 12, 22, 0.75));
+    border: 1px solid rgba(0, 229, 255, 0.18);
+    box-shadow: 0 30px 90px rgba(0, 229, 255, 0.18), 0 50px 120px rgba(255, 0, 224, 0.12);
     overflow: hidden;
+    isolation: isolate;
 }
 
-.editor-styles-wrapper .footer-cta::before {
+.editor-styles-wrapper .footer-shell::before,
+.editor-styles-wrapper .footer-shell::after {
     content: '';
     position: absolute;
-    inset: -15%;
-    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 65%);
-    filter: blur(55px);
-    opacity: 0.55;
+    inset: -30%;
+    background: radial-gradient(circle, rgba(0, 229, 255, 0.32), transparent 68%);
+    filter: blur(70px);
+    opacity: 0.45;
     z-index: 0;
 }
 
-.editor-styles-wrapper .footer-cta > * {
+.editor-styles-wrapper .footer-shell::after {
+    inset: -25% -25% -45% -25%;
+    background: radial-gradient(circle, rgba(255, 0, 224, 0.24), transparent 70%);
+    opacity: 0.35;
+}
+
+.editor-styles-wrapper .footer-shell > * {
     position: relative;
     z-index: 1;
 }
 
-.editor-styles-wrapper .footer-cta__title {
-    font-family: 'Caveat', cursive;
-    font-size: clamp(2.75rem, 8vw, 4.75rem);
-    color: var(--text-primary);
-    margin: 0 0 10px;
-    text-shadow: 0 0 16px rgba(0, 229, 255, 0.45), 0 0 24px rgba(255, 0, 224, 0.35);
-}
-
-.editor-styles-wrapper .footer-cta__description {
-    font-size: clamp(1rem, 2.6vw, 1.3rem);
-    color: var(--text-secondary);
-    margin: 0 0 clamp(20px, 4vw, 32px);
-    max-width: 620px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.editor-styles-wrapper .footer-cta__buttons {
+.editor-styles-wrapper .footer-headline {
     display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    justify-content: center;
-}
-
-.editor-styles-wrapper .footer-cta__link {
-    display: inline-flex;
+    flex-direction: column;
     align-items: center;
-    gap: 8px;
-    color: var(--neon-cyan);
-    font-weight: 700;
-    text-decoration: none;
-    padding: 14px 26px;
-    border-radius: 999px;
-    border: 1px solid rgba(0, 229, 255, 0.36);
-    background: rgba(9, 13, 21, 0.65);
+    gap: 12px;
+    text-align: center;
 }
 
-.editor-styles-wrapper .footer-cta__link,
-.editor-styles-wrapper .footer-nav a,
-.editor-styles-wrapper .footer-contact a {
-    outline-offset: 4px;
+.editor-styles-wrapper .footer-eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.32em;
+    font-size: 0.75rem;
+    color: rgba(230, 241, 255, 0.7);
+}
+
+.editor-styles-wrapper .footer-headline__title {
+    margin: 0;
+    font-family: 'Caveat', cursive;
+    font-size: clamp(2.2rem, 6vw, 3.6rem);
+    color: var(--text-primary);
+    text-shadow: 0 0 14px rgba(0, 229, 255, 0.5), 0 0 26px rgba(255, 0, 224, 0.35);
+}
+
+.editor-styles-wrapper .footer-headline__description {
+    margin: 0;
+    max-width: 640px;
+    font-size: clamp(1rem, 2.2vw, 1.25rem);
+    color: rgba(214, 231, 255, 0.85);
 }
 
 .editor-styles-wrapper .footer-divider {
@@ -296,6 +294,17 @@
     border-radius: 999px;
     background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.7), rgba(255, 0, 224, 0.6), transparent);
     opacity: 0.65;
+}
+
+.editor-styles-wrapper .footer-divider--subtle {
+    opacity: 0.35;
+    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.45), rgba(255, 0, 224, 0.4), transparent);
+}
+
+.editor-styles-wrapper .footer-nav a,
+.editor-styles-wrapper .footer-contact a {
+    outline: 2px solid var(--neon-cyan);
+    outline-offset: 4px;
 }
 
 .editor-styles-wrapper .footer-core {

--- a/parts/footer-neon.html
+++ b/parts/footer-neon.html
@@ -14,27 +14,21 @@
 
 <!-- wp:group {"className":"footer-container","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group footer-container">
-<!-- wp:group {"className":"footer-cta","layout":{"type":"constrained"}} -->
-<div class="wp-block-group footer-cta">
-<!-- wp:heading {"level":2,"className":"footer-cta__title"} -->
-<h2 class="footer-cta__title">Ready to build your next luminous launch?</h2>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph {"className":"footer-cta__description"} -->
-<p class="footer-cta__description">From bold strategy to neon-soaked visuals, we craft digital experiences that glow across every screen. Let&#8217;s make something unforgettable together.</p>
+<!-- wp:group {"className":"footer-shell","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap","verticalAlignment":"top"}} -->
+<div class="wp-block-group footer-shell">
+<!-- wp:group {"className":"footer-headline","layout":{"type":"constrained","justifyContent":"center"}} -->
+<div class="wp-block-group footer-headline">
+<!-- wp:paragraph {"className":"footer-eyebrow"} -->
+<p class="footer-eyebrow">Stay luminous</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:buttons {"className":"footer-cta__buttons"} -->
-<div class="wp-block-buttons footer-cta__buttons">
-<!-- wp:button {"className":"cta-button"} -->
-<div class="wp-block-button cta-button"><a class="wp-block-button__link cta-button" href="/contact"><span class="btn-text">Start a Project</span></a></div>
-<!-- /wp:button -->
+<!-- wp:heading {"level":2,"className":"footer-headline__title"} -->
+<h2 class="footer-headline__title">Ready to build your next luminous launch?</h2>
+<!-- /wp:heading -->
 
-<!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link footer-cta__link" href="/portfolio">View Our Work</a></div>
-<!-- /wp:button -->
-</div>
-<!-- /wp:buttons -->
+<!-- wp:paragraph {"className":"footer-headline__description"} -->
+<p class="footer-headline__description">From bold strategy to neon-soaked visuals, we craft digital experiences that glow across every screen. Let&#8217;s make something unforgettable together.</p>
+<!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->
 
@@ -104,11 +98,17 @@
 </div>
 <!-- /wp:group -->
 
+<!-- wp:group {"className":"footer-divider footer-divider--subtle","layout":{"type":"constrained"}} -->
+<div class="wp-block-group footer-divider footer-divider--subtle" aria-hidden="true"></div>
+<!-- /wp:group -->
+
 <!-- wp:group {"className":"site-info footer-legal","layout":{"type":"constrained"}} -->
 <div class="wp-block-group site-info footer-legal">
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">&copy; 2025 McCullough Digital. Crafted with heart, strategy, and a dash of neon.</p>
 <!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 </div>

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.17 - 2025-10-12 =
+* **Footer Shell Refresh:** Removed the standalone CTA card, re-centred the headline/description inside a single gradient shell, and tightened spacing so the neon footer feels intentional without leaving a huge black void beneath the legal line.
+
 = 1.2.16 - 2025-10-11 =
 * **Footer Refresh:** Versioned the neon footer template part to `footer-neon` and updated every template plus the PHP fallback so sites previously customised in the Site Editor now load the CTA-led grid without manual resets.
 * **Template Registration:** Registered the header and neon footer template parts in `theme.json` to keep them grouped correctly inside the Site Editor.

--- a/style.css
+++ b/style.css
@@ -501,11 +501,11 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 /* --- Footer --- */
 #colophon.site-footer {
     background-color: var(--background-dark);
-    padding: 80px 5%;
+    padding: clamp(56px, 8vw, 104px) 5%;
     color: var(--text-secondary);
     position: relative;
     overflow: hidden;
-    border-top: 2px solid var(--text-secondary);
+    border-top: 1px solid rgba(230, 241, 255, 0.22);
 }
 
 /* Starfield Background */
@@ -562,93 +562,80 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     margin: 0 auto;
     display: flex;
     flex-direction: column;
-    gap: clamp(40px, 6vw, 72px);
+    gap: clamp(32px, 5vw, 60px);
     position: relative;
     z-index: var(--z-index-content);
     align-items: stretch;
 }
 
-.footer-cta {
+.footer-shell {
     position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(28px, 4.5vw, 48px);
     padding: clamp(32px, 5vw, 56px);
-    border-radius: 32px;
+    border-radius: 36px;
     background:
-        radial-gradient(circle at 12% 18%, rgba(0, 229, 255, 0.32), transparent 62%),
-        radial-gradient(circle at 82% 24%, rgba(255, 0, 224, 0.26), transparent 60%),
-        rgba(10, 13, 22, 0.92);
-    border: 1px solid rgba(0, 229, 255, 0.22);
-    box-shadow: 0 25px 70px rgba(0, 229, 255, 0.18), 0 35px 90px rgba(255, 0, 224, 0.14);
+        radial-gradient(circle at 10% 18%, rgba(0, 229, 255, 0.3), transparent 60%),
+        radial-gradient(circle at 85% 20%, rgba(255, 0, 224, 0.24), transparent 58%),
+        linear-gradient(160deg, rgba(8, 12, 22, 0.9), rgba(8, 12, 22, 0.75));
+    border: 1px solid rgba(0, 229, 255, 0.18);
+    box-shadow: 0 30px 90px rgba(0, 229, 255, 0.18), 0 50px 120px rgba(255, 0, 224, 0.12);
     overflow: hidden;
-    text-align: center;
+    isolation: isolate;
 }
 
-.footer-cta::before {
+.footer-shell::before,
+.footer-shell::after {
     content: '';
     position: absolute;
-    inset: -15%;
-    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 65%);
-    filter: blur(55px);
-    opacity: 0.55;
+    inset: -30%;
+    background: radial-gradient(circle, rgba(0, 229, 255, 0.32), transparent 68%);
+    filter: blur(70px);
+    opacity: 0.45;
     z-index: 0;
 }
 
-.footer-cta > * {
+.footer-shell::after {
+    inset: -25% -25% -45% -25%;
+    background: radial-gradient(circle, rgba(255, 0, 224, 0.24), transparent 70%);
+    opacity: 0.35;
+}
+
+.footer-shell > * {
     position: relative;
     z-index: 1;
 }
 
-.footer-cta__title {
-    font-family: 'Caveat', cursive;
-    font-size: clamp(2.75rem, 8vw, 4.75rem);
-    color: var(--text-primary);
-    margin: 0 0 10px;
-    text-shadow: 0 0 16px rgba(0, 229, 255, 0.45), 0 0 24px rgba(255, 0, 224, 0.35);
-}
-
-.footer-cta__description {
-    font-size: clamp(1rem, 2.6vw, 1.3rem);
-    color: var(--text-secondary);
-    margin: 0 0 clamp(20px, 4vw, 32px);
-    max-width: 620px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.footer-cta__buttons {
+.footer-headline {
     display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    justify-content: center;
-}
-
-.footer-cta__link {
-    display: inline-flex;
+    flex-direction: column;
     align-items: center;
-    gap: 8px;
-    color: var(--neon-cyan);
-    font-weight: 700;
-    text-decoration: none;
-    padding: 14px 26px;
-    border-radius: 999px;
-    border: 1px solid rgba(0, 229, 255, 0.36);
-    background: rgba(9, 13, 21, 0.65);
-    transition: color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+    gap: 12px;
+    text-align: center;
 }
 
-.footer-cta__link:hover,
-.footer-cta__link:focus-visible {
-    color: var(--background-dark);
-    border-color: transparent;
-    transform: translateY(-3px);
-    box-shadow: 0 14px 40px rgba(0, 229, 255, 0.25);
-    background: linear-gradient(120deg, rgba(0, 229, 255, 0.95), rgba(255, 0, 224, 0.9));
+.footer-eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.32em;
+    font-size: 0.75rem;
+    color: rgba(230, 241, 255, 0.7);
 }
 
-.footer-cta__link:focus-visible,
-.footer-nav a:focus-visible,
-.footer-contact a:focus-visible {
-    outline: 2px solid var(--neon-cyan);
-    outline-offset: 4px;
+.footer-headline__title {
+    margin: 0;
+    font-family: 'Caveat', cursive;
+    font-size: clamp(2.2rem, 6vw, 3.6rem);
+    color: var(--text-primary);
+    text-shadow: 0 0 14px rgba(0, 229, 255, 0.5), 0 0 26px rgba(255, 0, 224, 0.35);
+}
+
+.footer-headline__description {
+    margin: 0;
+    max-width: 640px;
+    font-size: clamp(1rem, 2.2vw, 1.25rem);
+    color: rgba(214, 231, 255, 0.85);
 }
 
 .footer-divider {
@@ -656,6 +643,17 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     border-radius: 999px;
     background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.7), rgba(255, 0, 224, 0.6), transparent);
     opacity: 0.65;
+}
+
+.footer-divider--subtle {
+    opacity: 0.35;
+    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.45), rgba(255, 0, 224, 0.4), transparent);
+}
+
+.footer-nav a:focus-visible,
+.footer-contact a:focus-visible {
+    outline: 2px solid var(--neon-cyan);
+    outline-offset: 4px;
 }
 
 .footer-core {


### PR DESCRIPTION
## Summary
- replace the footer CTA card with a gradient-wrapped shell that keeps the neon headline and description while integrating with the core footer grid
- update front-end and editor styles to match the new shell treatment, tighten spacing, and retain focus outlines for links and contact details
- document the footer refresh in the agent notes, bug report, and changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db00de35108324a5aa7768f234769d