### PR TITLE
Flatten neon footer shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+- **Latest (2025-10-13):**
+    - Flattened the neon footer wrapper so the gradient glow now lives on the footer container, removed redundant dividers, and tightened spacing so the colophon spans edge-to-edge without an inner shell.
 - **Latest (2025-10-12):**
     - Replaced the standalone footer CTA card with a gradient-wrapped shell that keeps the neon glow, centres the headline/description, and tightens spacing so the legal line no longer floats above a vast black void.
 - **Latest (2025-10-11):**

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report now tracks the 2025-09-27 through 2025-10-11 sweeps, covering the gr
 
 ## Fixed Bugs
 
+### 2025-10-13 Sweep
+1. **Footer Shell Caused Redundant Padding & Dividers**
+   *Files:* `parts/footer-neon.html`, `style.css`, `editor-style.css`
+   *Issue:* The neon footer still wrapped its content in an inner `.footer-shell`, leaving duplicate padding, rounded edges, and gradient borders that stopped the section from spanning edge-to-edge. Legacy divider blocks also forced extra vertical spacing that made the legal line feel detached.
+   *Resolution:* Moved the gradient glow and padding directly onto `#colophon`, removed the shell wrapper, trimmed the layout gap, and replaced the thick dividers with a single slim separator so the footer breathes without an inner card.
+
 ### 2025-10-12 Sweep
 1. **Footer CTA Card Stuck Above Site Info**
    *Files:* `parts/footer-neon.html`, `style.css`, `editor-style.css`

--- a/editor-style.css
+++ b/editor-style.css
@@ -209,53 +209,50 @@
 }
 
 /* Footer Preview */
-.editor-styles-wrapper .footer-container {
-    max-width: min(1200px, 92vw);
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: clamp(32px, 5vw, 60px);
+.editor-styles-wrapper #colophon.site-footer {
     position: relative;
-    align-items: stretch;
-}
-
-.editor-styles-wrapper .footer-shell {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: clamp(28px, 4.5vw, 48px);
-    padding: clamp(32px, 5vw, 56px);
-    border-radius: 36px;
-    background:
+    padding: clamp(48px, 6vw, 84px) clamp(24px, 6vw, 64px);
+    color: var(--text-secondary);
+    background-color: var(--background-dark);
+    background-image:
         radial-gradient(circle at 10% 18%, rgba(0, 229, 255, 0.3), transparent 60%),
         radial-gradient(circle at 85% 20%, rgba(255, 0, 224, 0.24), transparent 58%),
-        linear-gradient(160deg, rgba(8, 12, 22, 0.9), rgba(8, 12, 22, 0.75));
-    border: 1px solid rgba(0, 229, 255, 0.18);
-    box-shadow: 0 30px 90px rgba(0, 229, 255, 0.18), 0 50px 120px rgba(255, 0, 224, 0.12);
+        linear-gradient(160deg, rgba(8, 12, 22, 0.9), rgba(8, 12, 22, 0.78));
     overflow: hidden;
     isolation: isolate;
 }
 
-.editor-styles-wrapper .footer-shell::before,
-.editor-styles-wrapper .footer-shell::after {
+.editor-styles-wrapper #colophon.site-footer::before,
+.editor-styles-wrapper #colophon.site-footer::after {
     content: '';
     position: absolute;
     inset: -30%;
     background: radial-gradient(circle, rgba(0, 229, 255, 0.32), transparent 68%);
     filter: blur(70px);
     opacity: 0.45;
-    z-index: 0;
+    pointer-events: none;
+    z-index: var(--z-index-default);
 }
 
-.editor-styles-wrapper .footer-shell::after {
+.editor-styles-wrapper #colophon.site-footer::after {
     inset: -25% -25% -45% -25%;
     background: radial-gradient(circle, rgba(255, 0, 224, 0.24), transparent 70%);
     opacity: 0.35;
 }
 
-.editor-styles-wrapper .footer-shell > * {
+.editor-styles-wrapper .footer-container {
+    max-width: min(1200px, 92vw);
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(28px, 4vw, 44px);
     position: relative;
-    z-index: 1;
+    align-items: stretch;
+}
+
+.editor-styles-wrapper .footer-container > * {
+    position: relative;
+    z-index: var(--z-index-default);
 }
 
 .editor-styles-wrapper .footer-headline {
@@ -289,16 +286,12 @@
     color: rgba(214, 231, 255, 0.85);
 }
 
-.editor-styles-wrapper .footer-divider {
+.editor-styles-wrapper .wp-block-separator.footer-separator {
+    margin: 0;
+    border: none;
     height: 1px;
-    border-radius: 999px;
-    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.7), rgba(255, 0, 224, 0.6), transparent);
-    opacity: 0.65;
-}
-
-.editor-styles-wrapper .footer-divider--subtle {
-    opacity: 0.35;
-    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.45), rgba(255, 0, 224, 0.4), transparent);
+    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.55), rgba(255, 0, 224, 0.5), transparent);
+    opacity: 0.45;
 }
 
 .editor-styles-wrapper .footer-nav a,

--- a/parts/footer-neon.html
+++ b/parts/footer-neon.html
@@ -14,8 +14,6 @@
 
 <!-- wp:group {"className":"footer-container","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap","verticalAlignment":"top"}} -->
 <div class="wp-block-group footer-container">
-<!-- wp:group {"className":"footer-shell","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap","verticalAlignment":"top"}} -->
-<div class="wp-block-group footer-shell">
 <!-- wp:group {"className":"footer-headline","layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group footer-headline">
 <!-- wp:paragraph {"className":"footer-eyebrow"} -->
@@ -30,10 +28,6 @@
 <p class="footer-headline__description">From bold strategy to neon-soaked visuals, we craft digital experiences that glow across every screen. Let&#8217;s make something unforgettable together.</p>
 <!-- /wp:paragraph -->
 </div>
-<!-- /wp:group -->
-
-<!-- wp:group {"className":"footer-divider","layout":{"type":"constrained"}} -->
-<div class="wp-block-group footer-divider" aria-hidden="true"></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"className":"footer-core","layout":{"type":"grid"}} -->
@@ -98,17 +92,15 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"className":"footer-divider footer-divider--subtle","layout":{"type":"constrained"}} -->
-<div class="wp-block-group footer-divider footer-divider--subtle" aria-hidden="true"></div>
-<!-- /wp:group -->
+<!-- wp:separator {"className":"footer-separator"} -->
+<hr class="wp-block-separator footer-separator"/>
+<!-- /wp:separator -->
 
 <!-- wp:group {"className":"site-info footer-legal","layout":{"type":"constrained"}} -->
 <div class="wp-block-group site-info footer-legal">
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">&copy; 2025 McCullough Digital. Crafted with heart, strategy, and a dash of neon.</p>
 <!-- /wp:paragraph -->
-</div>
-<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 </div>

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.18 - 2025-10-13 =
+* **Neon Footer Flattening:** Moved the gradient glow and padding onto the site footer itself, removed the inner shell wrapper, and swapped the chunky dividers for a slim separator so the section now stretches edge-to-edge without losing the neon wash.
+
 = 1.2.17 - 2025-10-12 =
 * **Footer Shell Refresh:** Removed the standalone CTA card, re-centred the headline/description inside a single gradient shell, and tightened spacing so the neon footer feels intentional without leaving a huge black void beneath the legal line.
 

--- a/style.css
+++ b/style.css
@@ -500,12 +500,34 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 
 /* --- Footer --- */
 #colophon.site-footer {
-    background-color: var(--background-dark);
-    padding: clamp(56px, 8vw, 104px) 5%;
-    color: var(--text-secondary);
     position: relative;
+    padding: clamp(48px, 6vw, 84px) clamp(24px, 6vw, 64px);
+    color: var(--text-secondary);
+    background-color: var(--background-dark);
+    background-image:
+        radial-gradient(circle at 10% 18%, rgba(0, 229, 255, 0.3), transparent 60%),
+        radial-gradient(circle at 85% 20%, rgba(255, 0, 224, 0.24), transparent 58%),
+        linear-gradient(160deg, rgba(8, 12, 22, 0.9), rgba(8, 12, 22, 0.78));
     overflow: hidden;
-    border-top: 1px solid rgba(230, 241, 255, 0.22);
+    isolation: isolate;
+}
+
+#colophon.site-footer::before,
+#colophon.site-footer::after {
+    content: '';
+    position: absolute;
+    inset: -30%;
+    background: radial-gradient(circle, rgba(0, 229, 255, 0.32), transparent 68%);
+    filter: blur(70px);
+    opacity: 0.45;
+    pointer-events: none;
+    z-index: var(--z-index-default);
+}
+
+#colophon.site-footer::after {
+    inset: -25% -25% -45% -25%;
+    background: radial-gradient(circle, rgba(255, 0, 224, 0.24), transparent 70%);
+    opacity: 0.35;
 }
 
 /* Starfield Background */
@@ -562,49 +584,15 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     margin: 0 auto;
     display: flex;
     flex-direction: column;
-    gap: clamp(32px, 5vw, 60px);
+    gap: clamp(28px, 4vw, 44px);
     position: relative;
     z-index: var(--z-index-content);
     align-items: stretch;
 }
 
-.footer-shell {
+.footer-container > * {
     position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: clamp(28px, 4.5vw, 48px);
-    padding: clamp(32px, 5vw, 56px);
-    border-radius: 36px;
-    background:
-        radial-gradient(circle at 10% 18%, rgba(0, 229, 255, 0.3), transparent 60%),
-        radial-gradient(circle at 85% 20%, rgba(255, 0, 224, 0.24), transparent 58%),
-        linear-gradient(160deg, rgba(8, 12, 22, 0.9), rgba(8, 12, 22, 0.75));
-    border: 1px solid rgba(0, 229, 255, 0.18);
-    box-shadow: 0 30px 90px rgba(0, 229, 255, 0.18), 0 50px 120px rgba(255, 0, 224, 0.12);
-    overflow: hidden;
-    isolation: isolate;
-}
-
-.footer-shell::before,
-.footer-shell::after {
-    content: '';
-    position: absolute;
-    inset: -30%;
-    background: radial-gradient(circle, rgba(0, 229, 255, 0.32), transparent 68%);
-    filter: blur(70px);
-    opacity: 0.45;
-    z-index: 0;
-}
-
-.footer-shell::after {
-    inset: -25% -25% -45% -25%;
-    background: radial-gradient(circle, rgba(255, 0, 224, 0.24), transparent 70%);
-    opacity: 0.35;
-}
-
-.footer-shell > * {
-    position: relative;
-    z-index: 1;
+    z-index: var(--z-index-default);
 }
 
 .footer-headline {
@@ -638,16 +626,12 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     color: rgba(214, 231, 255, 0.85);
 }
 
-.footer-divider {
+.wp-block-separator.footer-separator {
+    margin: 0;
+    border: none;
     height: 1px;
-    border-radius: 999px;
-    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.7), rgba(255, 0, 224, 0.6), transparent);
-    opacity: 0.65;
-}
-
-.footer-divider--subtle {
-    opacity: 0.35;
-    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.45), rgba(255, 0, 224, 0.4), transparent);
+    background: linear-gradient(90deg, transparent, rgba(0, 229, 255, 0.55), rgba(255, 0, 224, 0.5), transparent);
+    opacity: 0.45;
 }
 
 .footer-nav a:focus-visible,


### PR DESCRIPTION
## Summary
- remove the inner `.footer-shell` wrapper from the neon footer template so the content sits directly in the container and swaps the heavy dividers for a slim separator
- move the neon gradient, glow, and spacing to `#colophon.site-footer` and update the front-end/editor styles to keep the stars layered behind the content with the tightened layout
- document the footer flattening sweep in `AGENTS.md`, `bug-report.md`, and `readme.txt`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db467ee1fc832488390d01c15a891c