### PR TITLE
Fix hero top alignment gap and sync editor preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,11 @@ This repository contains the McCullough Digital block theme. The notes below sum
 - **Enhancement:** Added source map generation to webpack config for improved debugging in both development and production environments.
 - **Theme Version:** Bumped to 1.2.19 to reflect code quality improvements and WordPress API compliance fixes.
 
+### Latest (2025-10-19) - Hero Alignment Parity
+- Replaced the hero's top-alignment padding with a modest clamp so the section tucks beneath the fixed header without reopening a visible gap on desktop.
+- Mirrored the hero alignment classes, offset transform, and CTA positioning rules inside the editor stylesheet so Site Editor previews now match the live layouts.
+- Intensified the decorative hero image glow with layered drop shadows to mask the light halo left by background removal.
+
 ### Latest (2025-10-18) - Hero Layout Polish
 - Removed the duplicate masthead offset from the hero block so the section now sits flush beneath the fixed header while keepin
 g the top-aligned layout option intact.

--- a/blocks/hero/style.css
+++ b/blocks/hero/style.css
@@ -12,7 +12,7 @@
 
 .wp-block-mccullough-digital-hero.is-content-top {
     align-items: flex-start;
-    padding-top: var(--mcd-header-offset, var(--header-height));
+    padding-top: clamp(24px, 6vh, 96px);
 }
 
 .wp-block-mccullough-digital-hero.is-content-top .hero-content {
@@ -49,7 +49,9 @@
     width: 100%;
     height: auto;
     display: block;
-    filter: drop-shadow(0 10px 30px rgba(0, 0, 0, 0.5));
+    filter: drop-shadow(0 14px 40px rgba(11, 12, 16, 0.8))
+        drop-shadow(0 0 45px rgba(16, 18, 26, 0.75))
+        drop-shadow(0 0 60px rgba(0, 229, 255, 0.4));
 }
 
 /* Position variants */

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,22 @@ This report tracks all production-impacting fixes and continuous improvements in
 
 ## Fixed Bugs
 
+### 2025-10-19 Sweep
+1. **Hero Top Alignment Still Overpadded**
+   *Files:* `blocks/hero/style.css`, `style.css`, `readme.txt`, `AGENTS.md`, `bug-report.md`
+   *Issue:* Setting the hero content to `top` reinstated the full masthead offset, reopening a visible gap between the fixed header and the section on the live site.
+   *Resolution:* Replaced the header-height variable with a gentle clamp so the hero now tucks beneath the masthead while keeping a modest buffer for the content stack.
+
+2. **Hero Alignment Preview Drift in Editor**
+   *Files:* `editor-style.css`
+   *Issue:* The Site Editor ignored the hero alignment modifiers and offset variable, so top- or bottom-aligned layouts still appeared centred and the offset slider had no visible effect while authoring.
+   *Resolution:* Mirrored the front-end alignment classes, stack layout, and CTA offset styles inside the editor stylesheet so previews honour each vertical alignment and reflect the offset translation.
+
+3. **Decorative Hero Art Halo Visible**
+   *Files:* `blocks/hero/style.css`
+   *Issue:* The background-removed hero illustration retained a faint white fringe that bled through on dark canvases despite the existing drop shadow.
+   *Resolution:* Layered denser, tinted drop shadows to envelop the artwork edges and mask the halo without flattening the glow effect.
+
 ### 2025-10-18 Sweep
 1. **Hero Offset & CTA Elevation**
    *Files:* `blocks/hero/style.css`, `editor-style.css`

--- a/editor-style.css
+++ b/editor-style.css
@@ -152,10 +152,30 @@
     overflow: hidden;
 }
 
+.editor-styles-wrapper .hero.is-content-top {
+    align-items: flex-start;
+    padding-top: clamp(24px, 6vh, 96px);
+}
+
+.editor-styles-wrapper .hero.is-content-center {
+    align-items: center;
+}
+
+.editor-styles-wrapper .hero.is-content-bottom {
+    align-items: flex-end;
+}
+
+.editor-styles-wrapper .hero.is-content-top .hero-content {
+    padding-top: 40px;
+    margin-top: 0;
+}
+
 .editor-styles-wrapper .hero .wp-block-buttons {
     position: absolute;
     right: 8%;
-    bottom: clamp(64px, 12vh, 200px);
+    bottom: var(--hero-cta-offset, clamp(64px, 12vh, 200px));
+    transform: none;
+    z-index: 10;
 }
 
 .editor-styles-wrapper .hero-canvas-placeholder {
@@ -171,7 +191,13 @@
 .editor-styles-wrapper .hero-content {
     position: relative;
     z-index: 2;
-    max-width: 800px;
+    width: 100%;
+    max-width: 1400px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+    transform: translateY(var(--hero-content-offset, 0px));
 }
 
 .editor-styles-wrapper .hero h1 {

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,11 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.26 - 2025-10-19 =
+* **Hero Top Alignment:** Replaced the duplicated masthead offset with a gentle clamp so top-aligned hero layouts hug the fixed header without reopening the gap on desktop.
+* **Editor Parity:** Mirrored the hero alignment classes, content stack layout, and CTA offset variable inside `editor-style.css` so authors preview the same vertical behaviour as the front end while adjusting the offset slider.
+* **Decorative Glow:** Layered stronger drop shadows around the hero artwork to mask the light halo left by background removal against dark canvases.
+
 = 1.2.25 - 2025-10-18 =
 * **Hero Header Alignment:** Removed the extra masthead offset from the hero block and anchored the CTA buttons to a bottom off
 set so the section now sits flush beneath the fixed header while the desktop button rests lower on the canvas.

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.25
+Version:       1.2.26
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital


### PR DESCRIPTION
## Summary
- replace the hero block's top alignment padding with a clamp so the section sits directly beneath the header while enhancing the decorative artwork glow
- mirror the hero alignment classes, content stack layout, and CTA offset handling in the editor stylesheet for accurate previews
- document the changes in the project changelog, bug report, and agent notes and bump the theme version to 1.2.26

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc0e741d448324a3044d74d9ad3092