### PR TITLE
Fix hero CTA magnetic button reinitialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ This repository contains the McCullough Digital block theme. The notes below sum
 - **Enhancement:** Added source map generation to webpack config for improved debugging in both development and production environments.
 - **Theme Version:** Bumped to 1.2.19 to reflect code quality improvements and WordPress API compliance fixes.
 
+### Latest (2025-10-20) - Magnetic CTA Idempotency
+- Hardened the hero CTA magnetic button enhancement so repeated script loads reuse the existing glow/border layers, skip rewrapping nested markup, and simply rebind the GSAP listeners while leaving the DOM untouched.
+
 ### Latest (2025-10-19) - Hero Alignment Parity
 - Replaced the hero's top-alignment padding with a modest clamp so the section tucks beneath the fixed header without reopening a visible gap on desktop.
 - Mirrored the hero alignment classes, offset transform, and CTA positioning rules inside the editor stylesheet so Site Editor previews now match the live layouts.

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report tracks all production-impacting fixes and continuous improvements in
 
 ## Fixed Bugs
 
+### 2025-10-20 Sweep
+1. **Hero CTA Magnetic Layers Duplicating**
+   *Files:* `blocks/hero/view.js`, `style.css`, `readme.txt`, `AGENTS.md`, `bug-report.md`
+   *Issue:* Reinitialising the hero script wrapped CTA buttons repeatedly, duplicating the glow/border layers and breaking the GSAP jelly effect when the script loaded more than once.
+   *Resolution:* Added a dataset guard so previously enhanced buttons bail before DOM mutations, reuse existing glow/border/text wrappers, and rebind GSAP listeners idempotently so repeated loads leave a single glow/border pair while keeping the cursor tracking intact.
+
 ### 2025-10-19 Sweep
 1. **Hero Top Alignment Still Overpadded**
    *Files:* `blocks/hero/style.css`, `style.css`, `readme.txt`, `AGENTS.md`, `bug-report.md`

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.27 - 2025-10-20 =
+* **Hero CTA Magnetic Guard:** Prevented repeated hero script loads from duplicating button glow/border layers by reusing existing wrappers, wrapping only raw text nodes, and rebinding GSAP listeners without mutating the DOM.
+
 = 1.2.26 - 2025-10-19 =
 * **Hero Top Alignment:** Replaced the duplicated masthead offset with a gentle clamp so top-aligned hero layouts hug the fixed header without reopening the gap on desktop.
 * **Editor Parity:** Mirrored the hero alignment classes, content stack layout, and CTA offset variable inside `editor-style.css` so authors preview the same vertical behaviour as the front end while adjusting the offset slider.

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.26
+Version:       1.2.27
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital


### PR DESCRIPTION
## Summary
- guard hero CTA buttons against duplicate glow/border layers by reusing existing wrappers and skipping DOM mutations after the first enhancement
- ensure GSAP listeners are re-bound idempotently by storing cleanup hooks on each button and moving only raw text nodes into the text wrapper
- document the fix with a 1.2.27 changelog entry, version bump, and updated maintenance notes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc12bef0f88324ad7f6824b81da98f