### PR TITLE
Ensure hero CTA hydrates for inner content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ This repository contains the McCullough Digital block theme. The notes below sum
 
 ## Bug Fix & Improvement Highlights
 
+### Latest (2025-10-29) - Hero CTA Mount Reliability
+- **Hydration Everywhere:** The PHP render now wraps saved hero CTA buttons in a `.hero-neon-button-mount` wrapper and enqueues `build/blocks/hero/hero-button.js` whenever a call-to-action exists, so React hydrates in both the Site Editor preview and the published front end.
+- **Graceful Fallbacks:** The wrapper preserves the original `<a>` or `<button>` markup inside the mount, keeping the no-JavaScript experience accessible while exposing the CTA text/link to the React bundle.
+
 ### Latest (2025-10-28) - Hero CTA Link Semantics & Label Layout
 - **Accessibility:** The React jelly button now renders a `<motion.a>` whenever a link is provided, so keyboard modifiers, conte
 xt menus, and assistive technology see a real anchor while the motion-driven `<motion.button>` fallback remains for empty URLs.

--- a/blocks/hero/render.php
+++ b/blocks/hero/render.php
@@ -9,6 +9,163 @@
  * @package McCullough_Digital
  */
 
+if ( ! function_exists( 'mcd_hero_enqueue_button_script' ) ) {
+    /**
+     * Ensure the neon hero button script is loaded when a CTA is present.
+     *
+     * @return void
+     */
+    function mcd_hero_enqueue_button_script() {
+        $script_path = get_template_directory() . '/build/blocks/hero/hero-button.js';
+
+        if ( ! file_exists( $script_path ) ) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'mccullough-digital-hero-button',
+            get_template_directory_uri() . '/build/blocks/hero/hero-button.js',
+            array(),
+            filemtime( $script_path ),
+            true
+        );
+    }
+}
+
+if ( ! function_exists( 'mcd_hero_wrap_cta_markup' ) ) {
+    /**
+     * Wrap the saved CTA markup with the neon button mount so React can hydrate it.
+     *
+     * @param string $inner_content The saved InnerBlocks markup.
+     *
+     * @return array {
+     *     @type string $content        Updated markup with mount wrappers.
+     *     @type string $button_text    CTA label.
+     *     @type string $button_link    CTA URL if present.
+     *     @type string $fallback_type  Either "link" or "static".
+     *     @type bool   $found          Whether a CTA button was located.
+     * }
+     */
+    function mcd_hero_wrap_cta_markup( $inner_content ) {
+        $result = array(
+            'content'       => $inner_content,
+            'button_text'   => '',
+            'button_link'   => '',
+            'fallback_type' => 'static',
+            'found'         => false,
+        );
+
+        if ( '' === $inner_content ) {
+            return $result;
+        }
+
+        $previous_state = libxml_use_internal_errors( true );
+        $document       = new DOMDocument();
+
+        $content_to_load = '<div id="mcd-hero-inner-root">' . $inner_content . '</div>';
+        $loaded          = $document->loadHTML(
+            '<?xml encoding="utf-8" ?>' . $content_to_load,
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
+
+        if ( ! $loaded ) {
+            libxml_clear_errors();
+            libxml_use_internal_errors( $previous_state );
+            return $result;
+        }
+
+        $container = $document->getElementById( 'mcd-hero-inner-root' );
+
+        if ( ! $container ) {
+            libxml_clear_errors();
+            libxml_use_internal_errors( $previous_state );
+            return $result;
+        }
+
+        $xpath     = new DOMXPath( $document );
+        $cta_nodes = $xpath->query(
+            '//*[contains(concat(" ", normalize-space(@class), " "), " hero__cta-button ")]'
+        );
+
+        if ( ! $cta_nodes || 0 === $cta_nodes->length ) {
+            libxml_clear_errors();
+            libxml_use_internal_errors( $previous_state );
+            return $result;
+        }
+
+        foreach ( $cta_nodes as $cta_node ) {
+            $parent            = $cta_node->parentNode;
+            $already_wrapped   = false;
+            $ancestor          = $parent;
+
+            while ( $ancestor instanceof DOMElement ) {
+                $class_attribute = $ancestor->getAttribute( 'class' );
+
+                if ( false !== strpos( ' ' . $class_attribute . ' ', ' hero-neon-button-mount ' ) ) {
+                    $already_wrapped = true;
+                    break;
+                }
+
+                $ancestor = $ancestor->parentNode;
+            }
+
+            if ( $already_wrapped ) {
+                continue;
+            }
+
+            $cta_text = trim( wp_strip_all_tags( $cta_node->textContent ) );
+            $cta_href = '';
+
+            if ( $cta_node->hasAttribute( 'href' ) ) {
+                $candidate_href = trim( $cta_node->getAttribute( 'href' ) );
+                $sanitized_href = esc_url_raw( $candidate_href );
+
+                if ( '' !== $sanitized_href ) {
+                    $cta_href = $sanitized_href;
+                }
+            }
+
+            $fallback_type = '' === $cta_href ? 'static' : 'link';
+            $mount         = $document->createElement( 'div' );
+            $mount->setAttribute( 'class', 'hero-neon-button-mount' );
+
+            if ( '' !== $cta_text ) {
+                $mount->setAttribute( 'data-button-text', $cta_text );
+            }
+
+            if ( '' !== $cta_href ) {
+                $mount->setAttribute( 'data-button-link', $cta_href );
+            }
+
+            $mount->setAttribute( 'data-fallback-type', $fallback_type );
+
+            $parent->replaceChild( $mount, $cta_node );
+            $mount->appendChild( $cta_node );
+
+            $updated_markup = '';
+
+            foreach ( $container->childNodes as $child_node ) {
+                $updated_markup .= $document->saveHTML( $child_node );
+            }
+
+            $result = array(
+                'content'       => $updated_markup,
+                'button_text'   => $cta_text,
+                'button_link'   => $cta_href,
+                'fallback_type' => $fallback_type,
+                'found'         => ( '' !== $cta_text || '' !== $cta_href ),
+            );
+
+            break;
+        }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors( $previous_state );
+
+        return $result;
+    }
+}
+
 $headline   = isset( $attributes['headline'] ) ? $attributes['headline'] : '';
 $subheading = isset( $attributes['subheading'] ) ? $attributes['subheading'] : '';
 
@@ -46,6 +203,15 @@ $hide_image_on_mobile   = isset( $attributes['hideImageOnMobile'] ) && $attribut
 
 $inner_content = trim( (string) $content );
 
+if ( '' !== $inner_content ) {
+    $cta_wrapped = mcd_hero_wrap_cta_markup( $inner_content );
+
+    if ( ! empty( $cta_wrapped['found'] ) ) {
+        $inner_content = $cta_wrapped['content'];
+        mcd_hero_enqueue_button_script();
+    }
+}
+
 if ( '' === $inner_content ) {
     ob_start();
 
@@ -67,20 +233,14 @@ if ( '' === $inner_content ) {
         <?php
     }
 
-    $button_text = isset( $attributes['buttonText'] ) ? trim( (string) $attributes['buttonText'] ) : '';
+    $button_text = isset( $attributes['buttonText'] ) ? trim( wp_strip_all_tags( (string) $attributes['buttonText'] ) ) : '';
     $raw_link    = isset( $attributes['buttonLink'] ) ? trim( (string) $attributes['buttonLink'] ) : '';
     $button_link = '' !== $raw_link ? esc_url( $raw_link ) : '';
 
     // React Neon Button Mount Point
     if ( '' !== $button_text ) {
         // Enqueue the React button script
-        wp_enqueue_script(
-            'mccullough-digital-hero-button',
-            get_template_directory_uri() . '/build/blocks/hero/hero-button.js',
-            array(), // React & ReactDOM will be bundled by Webpack
-            filemtime( get_template_directory() . '/build/blocks/hero/hero-button.js' ),
-            true
-        );
+        mcd_hero_enqueue_button_script();
 
         $mount_attributes = array(
             'class'              => 'hero-neon-button-mount',

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report tracks all production-impacting fixes and continuous improvements in
 
 ## Fixed Bugs
 
+### 2025-10-29 Sweep
+1. **Hero CTA Mount Reliability**
+   *Files:* `blocks/hero/render.php`, `AGENTS.md`, `readme.txt`, `style.css`, `bug-report.md`
+   *Issue:* The neon CTA React bundle only enqueued when the hero fell back to attribute-driven markup, so edited InnerBlocks renders lost hydration in the Site Editor preview and on the live site. Without hydration, the neon button effect disappeared and reduced-motion fallbacks never activated.
+   *Resolution:* Always enqueue the hero CTA bundle whenever a button is present, wrap saved buttons in a `.hero-neon-button-mount` that exposes the label/link via data attributes, and keep the original markup inside the wrapper so no-JavaScript visitors retain a functional anchor/button fallback.
+
 ### 2025-10-28 Sweep
 1. **Hero CTA Link Semantics & Label Layout**
    *Files:* `blocks/hero/hero-button.js`, `blocks/hero/components/NeonJellyButton.jsx`, `build/blocks/hero/hero-button.js`, `AGENTS.md`, `readme.txt`, `style.css`, `bug-report.md`

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.35 - 2025-10-29 =
+* **Hero CTA Hydration Everywhere:** Always enqueue the neon jelly CTA script and wrap saved buttons in a `.hero-neon-button-mount` so Site Editor and front-end renders hydrate even when authors edit the inner `core/button`, while the original markup stays in place for no-JS fallbacks.
+
 = 1.2.34 - 2025-10-28 =
 * **Link Semantics Restored:** Allow the neon hero CTA to hydrate as a `<motion.a>` when a URL exists, preserving native link behaviours like new-tab navigation, context menus, and assistive tech exposure while keeping the button fallback for empty links.
 * **Responsive Label Layout:** Size the jelly button label and padding from the measured orb diameter and relax word breaking so default copy such as "Start a Project" stays horizontal instead of stacking each letter inside the sphere.

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:     https://mccullough.digital/
 Author:        McCullough Digital
 Author URI:    https://mccullough.digital/
 Description:   Custom theme scaffold with fixed header, mobile menu, and simple template hierarchy.
-Version:       1.2.34
+Version:       1.2.35
 License:       GNU General Public License v2 or later
 License URI:   http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:   mccullough-digital


### PR DESCRIPTION
## Summary
- wrap saved hero CTA markup in a `.hero-neon-button-mount` and always enqueue the neon bundle when a call-to-action exists
- preserve the fallback `<a>`/`<button>` inside the mount so no-JavaScript visitors keep an accessible CTA while React reads the data attributes
- document the hydration fix and bump the theme version to 1.2.35

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc96dfe1908324a19fa914f0c33cd8