### PR TITLE
Restore gradient sweep styling for hero CTA button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ This repository contains the McCullough Digital block theme. The notes below sum
 
 ## Bug Fix & Improvement Highlights
 
+### Latest (2025-11-01) - Hero CTA Gradient Sweep
+- **Animated Sweep:** Rebuilt the static `.hero__cta-button` styles in `blocks/hero/style.css` and `editor-style.css` so anchors and buttons share an inline-flex neon pill with the masthead gradient sweeping across on hover/focus while preserving a dark resting surface, halo glow, and accessible outlines.
+
 ### Latest (2025-10-31) - About Story Defaults
 - **Richer Defaults:** Updated the About block metadata to prefill mission, founder, and proof paragraphs plus a CTA button so every new insertion surfaces the full storytelling stack.
 - **Pattern Sync:** Rebuilt the Home Landing and standalone About section patterns to embed the same copy structure, ensuring seeded pages and manual inserts stay consistent.

--- a/blocks/hero/style.css
+++ b/blocks/hero/style.css
@@ -122,6 +122,84 @@
 
 .wp-block-mccullough-digital-hero .hero__cta-button {
     align-self: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.65ch;
+    margin-inline: auto;
+    padding: clamp(0.85rem, 2.5vw, 1.1rem) clamp(2.5rem, 6vw, 3.25rem);
+    font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-weight: 700;
+    font-size: clamp(1rem, 1.9vw, 1.15rem);
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    color: var(--text-primary, #e6f1ff);
+    background: linear-gradient(180deg, rgba(8, 11, 18, 0.78), rgba(8, 11, 18, 0.6));
+    border: 1px solid rgba(230, 241, 255, 0.22);
+    border-radius: 999px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+    position: relative;
+    overflow: hidden;
+    transition: color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease,
+        transform 0.35s ease, background-color 0.35s ease;
+    isolation: isolate;
+    z-index: 0;
+    cursor: pointer;
+    appearance: none;
+}
+
+.wp-block-mccullough-digital-hero .hero__cta-button::before,
+.wp-block-mccullough-digital-hero .hero__cta-button::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    transition: transform 0.55s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.45s ease;
+}
+
+.wp-block-mccullough-digital-hero .hero__cta-button::before {
+    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+    transform: translateX(110%);
+    opacity: 0.85;
+    z-index: -1;
+}
+
+.wp-block-mccullough-digital-hero .hero__cta-button::after {
+    inset: -35%;
+    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 55%),
+        radial-gradient(circle at 70% 30%, rgba(255, 0, 224, 0.3), transparent 60%);
+    opacity: 0;
+    transform: scale(0.9);
+    filter: blur(12px);
+    z-index: -2;
+}
+
+.wp-block-mccullough-digital-hero .hero__cta-button:hover,
+.wp-block-mccullough-digital-hero .hero__cta-button:focus-visible {
+    color: var(--background-dark, #0b0c10);
+    border-color: transparent;
+    box-shadow: 0 22px 46px rgba(0, 229, 255, 0.3), 0 0 42px rgba(255, 0, 224, 0.28);
+}
+
+.wp-block-mccullough-digital-hero .hero__cta-button:hover::before,
+.wp-block-mccullough-digital-hero .hero__cta-button:focus-visible::before {
+    transform: translateX(0);
+}
+
+.wp-block-mccullough-digital-hero .hero__cta-button:hover::after,
+.wp-block-mccullough-digital-hero .hero__cta-button:focus-visible::after {
+    opacity: 1;
+    transform: scale(1.05);
+}
+
+.wp-block-mccullough-digital-hero .hero__cta-button:focus-visible {
+    outline: 2px solid var(--neon-cyan);
+    outline-offset: 4px;
+}
+
+.wp-block-mccullough-digital-hero .hero__cta-button:focus:not(:focus-visible) {
+    outline: none;
 }
 
 

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report tracks all production-impacting fixes and continuous improvements in
 
 ## Fixed Bugs
 
+### 2025-11-01 Sweep
+1. **Hero CTA Gradient Sweep**
+   *Files:* `blocks/hero/style.css`, `editor-style.css`, `AGENTS.md`, `bug-report.md`, `readme.txt`
+   *Issue:* The simplified hero CTA reverted to the generic `.cta-button` styling, losing the masthead's gradient sweep, halo, and focus polish in both the front end and Site Editor previews.
+   *Resolution:* Reintroduced a dedicated `.hero__cta-button` treatment with inline-flex layout, dark resting surface, gradient hover sweep, halo glow, and matching editor styles plus accessible focus outlines.
+
 ### 2025-10-31 Sweep
 1. **About Block Story Defaults**
    *Files:* `blocks/about/block.json`, `blocks/about/editor.js`, `patterns/home-landing.php`, `patterns/about-section.php`, `build/blocks/about/editor.js`, `AGENTS.md`, `bug-report.md`, `readme.txt`, `style.css`

--- a/editor-style.css
+++ b/editor-style.css
@@ -199,6 +199,87 @@
     margin-top: auto;
 }
 
+.editor-styles-wrapper .hero__cta-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.65ch;
+    margin-inline: auto;
+    padding: clamp(0.85rem, 2.5vw, 1.1rem) clamp(2.5rem, 6vw, 3.25rem);
+    font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-weight: 700;
+    font-size: clamp(1rem, 1.9vw, 1.15rem);
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    color: var(--text-primary, #e6f1ff);
+    background: linear-gradient(180deg, rgba(8, 11, 18, 0.78), rgba(8, 11, 18, 0.6));
+    border: 1px solid rgba(230, 241, 255, 0.22);
+    border-radius: 999px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+    position: relative;
+    overflow: hidden;
+    transition: color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease,
+        transform 0.35s ease, background-color 0.35s ease;
+    isolation: isolate;
+    z-index: 0;
+    cursor: pointer;
+    appearance: none;
+}
+
+.editor-styles-wrapper .hero__cta-button::before,
+.editor-styles-wrapper .hero__cta-button::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    transition: transform 0.55s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.45s ease;
+}
+
+.editor-styles-wrapper .hero__cta-button::before {
+    background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
+    transform: translateX(110%);
+    opacity: 0.85;
+    z-index: -1;
+}
+
+.editor-styles-wrapper .hero__cta-button::after {
+    inset: -35%;
+    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 55%),
+        radial-gradient(circle at 70% 30%, rgba(255, 0, 224, 0.3), transparent 60%);
+    opacity: 0;
+    transform: scale(0.9);
+    filter: blur(12px);
+    z-index: -2;
+}
+
+.editor-styles-wrapper .hero__cta-button:hover,
+.editor-styles-wrapper .hero__cta-button:focus-visible {
+    color: var(--background-dark);
+    border-color: transparent;
+    box-shadow: 0 22px 46px rgba(0, 229, 255, 0.3), 0 0 42px rgba(255, 0, 224, 0.28);
+}
+
+.editor-styles-wrapper .hero__cta-button:hover::before,
+.editor-styles-wrapper .hero__cta-button:focus-visible::before {
+    transform: translateX(0);
+}
+
+.editor-styles-wrapper .hero__cta-button:hover::after,
+.editor-styles-wrapper .hero__cta-button:focus-visible::after {
+    opacity: 1;
+    transform: scale(1.05);
+}
+
+.editor-styles-wrapper .hero__cta-button:focus-visible {
+    outline: 2px solid var(--neon-cyan);
+    outline-offset: 4px;
+}
+
+.editor-styles-wrapper .hero__cta-button:focus:not(:focus-visible) {
+    outline: none;
+}
+
 .editor-styles-wrapper .hero-content > .wp-block-buttons {
     width: 100%;
     display: flex;

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,9 @@ This theme does not have any widget areas registered by default.
 
 == Changelog ==
 
+= 1.2.38 - Unreleased =
+* **Hero CTA Gradient Sweep:** Refresh the `.hero__cta-button` styling with an inline-flex neon pill, masthead-inspired gradient hover sweep, halo glow, and matching Site Editor treatment while keeping the dark resting surface and focus outline accessible.
+
 = 1.2.37 - 2025-10-31 =
 * **About Story Defaults:** Seed the About block and its companion patterns with mission, founder, proof, and CTA copy so new installs and reinserts surface the full narrative without manual editing.
 


### PR DESCRIPTION
## Summary
- rebuild the hero CTA surface with an inline-flex neon pill, gradient sweep, and hover/focus halo
- mirror the CTA styling updates in the Site Editor stylesheet for preview parity
- document the styling sweep in the project notes, bug report, and changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd75ed463c8324a731e32ff7932532