### PR TITLE
Fix hero CTA base tint and sweep direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ This repository contains the McCullough Digital block theme. The notes below sum
 
 ## Bug Fix & Improvement Highlights
 
+### Latest (2025-11-02) - Hero CTA Sweep Direction & Base
+- **Transparent Base:** Lightened the `.hero__cta-button` resting surface in `blocks/hero/style.css` and `editor-style.css` to a nearly transparent tint so the pill no longer shows a dark interior before the gradient sweep animates.
+- **Left-to-Right Fill:** Flipped the sweep pseudo-element to rest off the left edge, producing the requested left-to-right gradient reveal on hover and focus in both the front end and Site Editor previews.
+
 ### Latest (2025-11-01) - Hero CTA Gradient Sweep
 - **Animated Sweep:** Rebuilt the static `.hero__cta-button` styles in `blocks/hero/style.css` and `editor-style.css` so anchors and buttons share an inline-flex neon pill with the masthead gradient sweeping across on hover/focus while preserving a dark resting surface, halo glow, and accessible outlines.
 

--- a/blocks/hero/style.css
+++ b/blocks/hero/style.css
@@ -134,7 +134,7 @@
     letter-spacing: 0.04em;
     text-decoration: none;
     color: var(--text-primary, #e6f1ff);
-    background: linear-gradient(180deg, rgba(8, 11, 18, 0.78), rgba(8, 11, 18, 0.6));
+    background-color: rgba(8, 11, 18, 0.08);
     border: 1px solid rgba(230, 241, 255, 0.22);
     border-radius: 999px;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
@@ -160,7 +160,7 @@
 
 .wp-block-mccullough-digital-hero .hero__cta-button::before {
     background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
-    transform: translateX(110%);
+    transform: translateX(-110%);
     opacity: 0.85;
     z-index: -1;
 }

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report tracks all production-impacting fixes and continuous improvements in
 
 ## Fixed Bugs
 
+### 2025-11-02 Sweep
+1. **Hero CTA Sweep Direction & Base Tint**
+   *Files:* `blocks/hero/style.css`, `editor-style.css`, `AGENTS.md`, `bug-report.md`, `readme.txt`
+   *Issue:* The hero call-to-action still displayed a dark pill at rest and the gradient sweep animated from right to left, clashing with the left-to-right creative direction and leaving the button interior dull until hover completed.
+   *Resolution:* Replaced the dark resting gradient with a nearly transparent base tint so the pill stays luminous before interaction, and shifted the sweep pseudo-element to start off the left edge, producing a left-to-right gradient fill across both the live site and Site Editor preview.
+
 ### 2025-11-01 Sweep
 1. **Hero CTA Gradient Sweep**
    *Files:* `blocks/hero/style.css`, `editor-style.css`, `AGENTS.md`, `bug-report.md`, `readme.txt`

--- a/editor-style.css
+++ b/editor-style.css
@@ -212,7 +212,7 @@
     letter-spacing: 0.04em;
     text-decoration: none;
     color: var(--text-primary, #e6f1ff);
-    background: linear-gradient(180deg, rgba(8, 11, 18, 0.78), rgba(8, 11, 18, 0.6));
+    background-color: rgba(8, 11, 18, 0.08);
     border: 1px solid rgba(230, 241, 255, 0.22);
     border-radius: 999px;
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
@@ -238,7 +238,7 @@
 
 .editor-styles-wrapper .hero__cta-button::before {
     background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
-    transform: translateX(110%);
+    transform: translateX(-110%);
     opacity: 0.85;
     z-index: -1;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -34,7 +34,7 @@ This theme does not have any widget areas registered by default.
 == Changelog ==
 
 = 1.2.38 - Unreleased =
-* **Hero CTA Gradient Sweep:** Refresh the `.hero__cta-button` styling with an inline-flex neon pill, masthead-inspired gradient hover sweep, halo glow, and matching Site Editor treatment while keeping the dark resting surface and focus outline accessible.
+* **Hero CTA Gradient Sweep:** Lighten the `.hero__cta-button` resting tint and flip the sweep animation to originate from the left, ensuring the neon gradient floods the pill left-to-right in both the front end and Site Editor while preserving the glow and focus outline.
 
 = 1.2.37 - 2025-10-31 =
 * **About Story Defaults:** Seed the About block and its companion patterns with mission, founder, proof, and CTA copy so new installs and reinserts surface the full narrative without manual editing.


### PR DESCRIPTION
## Summary
- lighten the hero CTA resting tint so the pill no longer appears as a dark interior
- reverse the gradient sweep animation to travel left-to-right in both front-end and editor styles
- document the visual update across AGENTS.md, bug-report.md, and readme.txt

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd78962fb08324816826ad70116603