### PR TITLE
Fix hero neon button alignment and popover clipping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+-### Latest (2025-11-06) - Hero CTA Alignment & Popover Fixes
+- **Editor Popovers Freed:** Released the hero wrapper's overflow clamp and moved clipping to the canvas/image layers so the neon button's URL popover opens fully in the Site Editor.
+- **Alignment Controls Restored:** Removed hero-specific centring overrides and updated the neon button block so align and spacing controls now position the CTA left, centre, or right with custom breathing room.
 
 -### Latest (2025-11-05) - Section CTA Defaults Trimmed
 - **Hero-Only Seeding:** Kept the neon CTA auto-inserted for the hero while removing it from the About and CTA default templates so those sections stay optional by default yet still allow the custom button to be added manually.

--- a/blocks/button/style.css
+++ b/blocks/button/style.css
@@ -21,7 +21,9 @@
     align-items: center;
     justify-content: center;
     gap: 0.65ch;
-    margin-inline: auto;
+    margin-left: 0;
+    margin-right: 0;
+    align-self: auto;
     padding: clamp(0.85rem, 2.5vw, 1.1rem) clamp(2.5rem, 6vw, 3.25rem);
     font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
     font-weight: 700;
@@ -41,6 +43,19 @@
     z-index: 0;
     cursor: pointer;
     appearance: none;
+}
+
+.wp-block-mccullough-digital-button.alignleft .hero__cta-button {
+    margin-right: auto;
+}
+
+.wp-block-mccullough-digital-button.alignright .hero__cta-button {
+    margin-left: auto;
+}
+
+.wp-block-mccullough-digital-button.aligncenter .hero__cta-button {
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .wp-block-mccullough-digital-button .hero__cta-button::before,

--- a/blocks/hero/style.css
+++ b/blocks/hero/style.css
@@ -7,7 +7,6 @@
     text-align: center;
     position: relative; /* Needed for positioning the canvas */
     background: radial-gradient(circle, rgba(20,22,28,0.9) 0%, var(--background-dark) 70%);
-    overflow: hidden; /* Hide anything that goes outside the hero */
 }
 
 .wp-block-mccullough-digital-hero.is-content-top {
@@ -35,6 +34,19 @@
     width: 100%;
     height: 100%;
     z-index: 1;
+    border-radius: inherit;
+    overflow: hidden;
+}
+
+.wp-block-mccullough-digital-hero .hero-canvas-placeholder {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: inherit;
+    overflow: hidden;
+    background: radial-gradient(circle at 20% 20%, rgba(0, 229, 255, 0.25), transparent 60%),
+        radial-gradient(circle at 80% 30%, rgba(255, 0, 224, 0.2), transparent 60%),
+        radial-gradient(circle at 50% 80%, rgba(148, 0, 211, 0.25), transparent 65%);
 }
 
 /* --- Hero Decorative Image --- */
@@ -43,6 +55,8 @@
     height: auto;
     z-index: 2; /* Below text (z-index: 3) but above canvas (z-index: 1) */
     pointer-events: none;
+    border-radius: inherit;
+    overflow: hidden;
 }
 
 .wp-block-mccullough-digital-hero .hero__decorative-image {
@@ -122,13 +136,45 @@
     justify-content: center;
 }
 
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-buttons.alignleft,
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-mccullough-digital-button.alignleft {
+    justify-content: flex-start;
+}
+
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-buttons.alignright,
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-mccullough-digital-button.alignright {
+    justify-content: flex-end;
+}
+
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-buttons.aligncenter,
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-mccullough-digital-button.aligncenter {
+    justify-content: center;
+}
+
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-buttons.alignleft .hero__cta-button,
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-mccullough-digital-button.alignleft .hero__cta-button {
+    margin-right: auto;
+}
+
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-buttons.alignright .hero__cta-button,
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-mccullough-digital-button.alignright .hero__cta-button {
+    margin-left: auto;
+}
+
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-buttons.aligncenter .hero__cta-button,
+.wp-block-mccullough-digital-hero .hero-content > .wp-block-mccullough-digital-button.aligncenter .hero__cta-button {
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .wp-block-mccullough-digital-hero .hero__cta-button {
-    align-self: center;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 0.65ch;
-    margin-inline: auto;
+    margin-left: 0;
+    margin-right: 0;
+    align-self: auto;
     padding: clamp(0.85rem, 2.5vw, 1.1rem) clamp(2.5rem, 6vw, 3.25rem);
     font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
     font-weight: 700;

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report tracks all production-impacting fixes and continuous improvements in
 
 ## Fixed Bugs
 
+### 2025-11-06 Sweep
+1. **Hero Neon Button Alignment & Popover Access**
+   *Files:* `blocks/hero/style.css`, `blocks/button/style.css`, `editor-style.css`, `AGENTS.md`, `bug-report.md`, `readme.txt`
+   *Issue:* The hero block's overflow clamp cut off the neon button's link popover in the Site Editor, while hero and button styles forced the CTA wrapper and button to stay centred, preventing align left/right selections and squashing custom spacing.
+   *Resolution:* Shifted overflow clipping to the canvas and decorative image layers so toolbar popovers can escape the hero wrapper, and removed the forced centring rules so the neon button now honours align classes and custom margins across the hero and standalone block.
+
 ### 2025-11-05 Sweep
 1. **Section CTA Defaults Trimmed**
    *Files:* `blocks/about/block.json`, `blocks/about/editor.js`, `blocks/cta/block.json`, `blocks/cta/editor.js`, `AGENTS.md`, `bug-report.md`, `readme.txt`

--- a/editor-style.css
+++ b/editor-style.css
@@ -149,7 +149,6 @@
     text-align: center;
     position: relative;
     background: radial-gradient(circle, rgba(20, 22, 28, 0.9) 0%, var(--background-dark) 70%);
-    overflow: hidden;
 }
 
 .editor-styles-wrapper .hero.is-content-top {
@@ -179,6 +178,15 @@
         radial-gradient(circle at 50% 80%, rgba(148, 0, 211, 0.25), transparent 65%);
     z-index: 1;
     border-radius: inherit;
+    overflow: hidden;
+}
+
+.editor-styles-wrapper .hero__particle-canvas {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: inherit;
+    overflow: hidden;
 }
 
 .editor-styles-wrapper .hero-content {
@@ -205,7 +213,9 @@
     align-items: center;
     justify-content: center;
     gap: 0.65ch;
-    margin-inline: auto;
+    margin-left: 0;
+    margin-right: 0;
+    align-self: auto;
     padding: clamp(0.85rem, 2.5vw, 1.1rem) clamp(2.5rem, 6vw, 3.25rem);
     font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
     font-weight: 700;
@@ -294,8 +304,35 @@
     justify-content: center;
 }
 
-.editor-styles-wrapper .hero__cta-button {
-    align-self: center;
+.editor-styles-wrapper .hero-content > .wp-block-buttons.alignleft,
+.editor-styles-wrapper .hero-content > .wp-block-mccullough-digital-button.alignleft {
+    justify-content: flex-start;
+}
+
+.editor-styles-wrapper .hero-content > .wp-block-buttons.alignright,
+.editor-styles-wrapper .hero-content > .wp-block-mccullough-digital-button.alignright {
+    justify-content: flex-end;
+}
+
+.editor-styles-wrapper .hero-content > .wp-block-buttons.aligncenter,
+.editor-styles-wrapper .hero-content > .wp-block-mccullough-digital-button.aligncenter {
+    justify-content: center;
+}
+
+.editor-styles-wrapper .hero-content > .wp-block-buttons.alignleft .hero__cta-button,
+.editor-styles-wrapper .hero-content > .wp-block-mccullough-digital-button.alignleft .hero__cta-button {
+    margin-right: auto;
+}
+
+.editor-styles-wrapper .hero-content > .wp-block-buttons.alignright .hero__cta-button,
+.editor-styles-wrapper .hero-content > .wp-block-mccullough-digital-button.alignright .hero__cta-button {
+    margin-left: auto;
+}
+
+.editor-styles-wrapper .hero-content > .wp-block-buttons.aligncenter .hero__cta-button,
+.editor-styles-wrapper .hero-content > .wp-block-mccullough-digital-button.aligncenter .hero__cta-button {
+    margin-left: auto;
+    margin-right: auto;
 }
 
 
@@ -605,6 +642,8 @@
     height: auto;
     z-index: 1;
     pointer-events: none;
+    border-radius: inherit;
+    overflow: hidden;
 }
 
 .editor-styles-wrapper .hero__decorative-image {

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,7 @@ This theme does not have any widget areas registered by default.
 == Changelog ==
 
 = 1.2.38 - Unreleased =
+* **Hero CTA Alignment Controls:** Freed the hero wrapper overflow and centring overrides so the neon button's URL popover opens fully while align and spacing controls can park the CTA left, centre, or right with extra breathing room.
 * **Section CTA Allowlist:** Updated the hero, services, about, and CTA sections to allow the `mccullough-digital/button` block while keeping the neon CTA auto-seeded only in the hero so other sections stay optional by default.
 * **Standalone Neon Button Block:** Added a reusable `mccullough-digital/button` block so editors can drop the hero's gradient sweep CTA anywhere, complete with toolbar link control and optional new-tab toggle.
 * **Hero CTA Gradient Sweep:** Lighten the `.hero__cta-button` resting tint and flip the sweep animation to originate from the left, ensuring the neon gradient floods the pill left-to-right in both the front end and Site Editor while preserving the glow and focus outline.


### PR DESCRIPTION
## Summary
- let the hero neon button toolbar popover escape clipping by moving overflow constraints to the canvas and image layers in both front-end and editor styles
- allow neon button alignment and spacing controls to take effect by removing forced centering in hero and button styles
- document the hero alignment and popover fixes across the project notes and changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd9e86c8388324aed56468f605c896