### PR TITLE
Clamp header logo sizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+-### Latest (2025-11-08) - Header Logo Sizing Clamp
+- **Front-End Guard:** Scoped the masthead logo rule to `.site-header .custom-logo` and `.wp-block-site-logo .custom-logo`, kept the height tied to `--logo-size-header`, and added responsive max constraints so oversized uploads stop stretching the fixed header while preserving intrinsic width.
+- **Editor Parity:** Mirrored the scoped selector and sizing cap in `editor-style.css` so the Site Editor preview matches the front-end masthead behaviour and no longer shifts the header offset when authors swap logos.
 -### Latest (2025-11-07) - Neon Blog Archive Template
 - **Blog Mockup Landed:** Rebuilt the archive and index templates with the radial hero, search bar, category filters, and featured-first post grid so the blog listing mirrors the latest design while keeping the layout driven by blocks and patterns.
 - **Style Sync:** Added the blog hero, filter pills, card grid, and pagination treatments to `style.css` and `editor-style.css`, ensuring the Site Editor preview matches the front end and the new pattern keeps semantic `<article>` wrappers for each post.

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report tracks all production-impacting fixes and continuous improvements in
 
 ## Fixed Bugs
 
+### 2025-11-08 Sweep
+1. **Header Logo Sizing Clamp**
+   *Files:* `style.css`, `editor-style.css`, `AGENTS.md`, `readme.txt`, `bug-report.md`
+   *Issue:* Oversized brand uploads relied on the core `.wp-block-site-logo img` rule, causing the masthead logo to exceed `--logo-size-header`, stretch the fixed header, and spike the `--mcd-header-offset` calculation in both the front end and Site Editor preview.
+   *Resolution:* Scoped the masthead logo styling to `.site-header .custom-logo` and `.wp-block-site-logo .custom-logo`, tied the height to `--logo-size-header`, and added responsive width and max-height constraints in both CSS bundles so oversized files scale down without disturbing the header offset or Site Editor preview.
+
 ### 2025-11-07 Sweep
 1. **Neon Blog Archive Template**
    *Files:* `templates/archive.html`, `templates/index.html`, `patterns/post-card-grid.php`, `style.css`, `editor-style.css`, `AGENTS.md`, `readme.txt`

--- a/editor-style.css
+++ b/editor-style.css
@@ -31,6 +31,18 @@
     background-color: var(--background-dark);
 }
 
+.editor-styles-wrapper .site-header .custom-logo,
+.editor-styles-wrapper .wp-block-site-logo .custom-logo {
+    height: var(--logo-size-header);
+    max-height: var(--logo-size-header);
+    width: auto;
+    max-width: 100%;
+    display: block;
+    transition: all 0.3s ease;
+    filter: drop-shadow(0 0 5px rgba(0, 229, 255, 0.6));
+    will-change: transform, filter;
+}
+
 .editor-styles-wrapper a {
     color: var(--neon-cyan);
 }

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,7 @@ This theme does not have any widget areas registered by default.
 == Changelog ==
 
 = 1.2.39 - Unreleased =
+* **Header Logo Clamp:** Scoped the masthead logo styling to outrank WordPress core selectors and added max constraints so oversize uploads respect `--logo-size-header` without inflating the fixed header or Site Editor preview.
 * **Neon Blog Archive Template:** Rebuilt the archive and index templates around a radial hero, live search, pill-style category filters, and a featured post grid with matching editor styles so the blog listing mirrors the new mockup without duplicating markup in patterns.
 
 = 1.2.38 - 2025-11-06 =

--- a/style.css
+++ b/style.css
@@ -200,9 +200,12 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     transition: transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1);
 }
 
-.custom-logo {
+.site-header .custom-logo,
+.wp-block-site-logo .custom-logo {
     height: var(--logo-size-header);
+    max-height: var(--logo-size-header);
     width: auto;
+    max-width: 100%;
     display: block;
     transition: all 0.3s ease;
     filter: drop-shadow(0 0 5px rgba(0, 229, 255, 0.6));


### PR DESCRIPTION
## Summary
- scope the masthead logo styling to outrank core selectors and clamp oversized uploads to the header logo size token
- mirror the scoped selector and sizing cap in the editor stylesheet so previews stay aligned
- document the header logo fix in the agent notes, bug report, and changelog

## Testing
- Not run (WordPress environment not available)

------
https://chatgpt.com/codex/tasks/task_e_68ddbc423f2c8324913e419a92ffb962