### PR TITLE
Add dynamic blog archive loop block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+-### Latest (2025-11-10) - Blog Archive Loop Block
+- **Dynamic Loop:** Added a `mccullough-digital/blog-archive-loop` server-rendered block that outputs the curated category pills, a standalone latest-post hero, the remaining grid, and pagination while respecting the active archive context.
+- **Markup Cleanup:** Replaced the template-level Query Loop with the new block in `templates/index.html` and `templates/archive.html`, updated search/404 templates to the shared `.post-grid` class, and trimmed the post-card pattern so badges are exclusive to the featured hero.
+- **Style Refresh:** Rebuilt front-end and editor CSS for the latest hero, pills, and grid; introduced placeholder fallbacks, empty-state messaging, and focus-visible states so the layout mirrors the mockup across devices.
+- **Docs Synced:** Recorded the loop block addition and styling refresh across `AGENTS.md`, `bug-report.md`, and `readme.txt`.
 -### Latest (2025-11-09) - Blog Hero Glitch & Badge Guard
 - **Hero Glitch Clone:** Mirrored the hero block's per-letter glitch treatment on the blog archive title via `js/header-scripts.js` and scoped `.blog-hero__letter` styles in both CSS bundles, complete with reduced-motion fallbacks.
 - **Badge Filter:** Added a `render_block` guard that only surfaces the "Most Recent" badge on the main blog query's first page, ensuring paged archives and secondary loops no longer mislabel older posts.

--- a/blocks/blog-archive-loop/block.json
+++ b/blocks/blog-archive-loop/block.json
@@ -1,0 +1,12 @@
+{
+    "apiVersion": 3,
+    "name": "mccullough-digital/blog-archive-loop",
+    "title": "Blog Archive Loop",
+    "category": "mcd-blocks",
+    "description": "Outputs the curated category pills, featured latest post, and blog card grid with pagination.",
+    "supports": {
+        "align": false,
+        "html": false
+    },
+    "render": "file:./render.php"
+}

--- a/blocks/blog-archive-loop/render.php
+++ b/blocks/blog-archive-loop/render.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Server-side rendering for the Blog Archive Loop block.
+ *
+ * @package McCullough_Digital
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'mcd_render_category_pills' ) ) {
+    /**
+     * Render the curated category pill navigation.
+     *
+     * @return string
+     */
+    function mcd_render_category_pills() {
+        $items = [
+            [
+                'label' => __( 'All Posts', 'mccullough-digital' ),
+                'slug'  => '',
+                'type'  => 'all',
+            ],
+            [
+                'label' => __( 'Web Design', 'mccullough-digital' ),
+                'slug'  => 'web-design',
+                'type'  => 'category',
+            ],
+            [
+                'label' => __( 'Development', 'mccullough-digital' ),
+                'slug'  => 'development',
+                'type'  => 'category',
+            ],
+            [
+                'label' => __( 'WordPress', 'mccullough-digital' ),
+                'slug'  => 'wordpress',
+                'type'  => 'category',
+            ],
+            [
+                'label' => __( 'UI/UX', 'mccullough-digital' ),
+                'slug'  => 'ui-ux',
+                'type'  => 'category',
+            ],
+            [
+                'label' => __( 'Tutorials', 'mccullough-digital' ),
+                'slug'  => 'tutorials',
+                'type'  => 'category',
+            ],
+        ];
+
+        $posts_page_id = (int) get_option( 'page_for_posts' );
+        $posts_page    = $posts_page_id ? get_permalink( $posts_page_id ) : home_url( '/' );
+
+        $output = '<ul class="category-filters__list">';
+
+        foreach ( $items as $item ) {
+            $label      = $item['label'];
+            $slug       = $item['slug'];
+            $is_current = false;
+            $url        = $posts_page;
+
+            if ( 'category' === $item['type'] ) {
+                $term = get_term_by( 'slug', $slug, 'category' );
+
+                if ( $term && ! is_wp_error( $term ) ) {
+                    $term_link = get_term_link( $term );
+                    if ( ! is_wp_error( $term_link ) ) {
+                        $url = $term_link;
+                    }
+                } else {
+                    $url = home_url( '/category/' . $slug . '/' );
+                }
+
+                $is_current = is_category( $slug );
+            } else {
+                $is_current = is_home() || is_post_type_archive( 'post' );
+            }
+
+            $classes = [ 'category-pill' ];
+
+            if ( $is_current ) {
+                $classes[] = 'is-active';
+            }
+
+            $data_attr = $slug ? ' data-category="' . esc_attr( $slug ) . '"' : ' data-category="all"';
+
+            $output .= sprintf(
+                '<li><a class="%1$s" href="%2$s"%3$s>%4$s</a></li>',
+                esc_attr( implode( ' ', $classes ) ),
+                esc_url( $url ),
+                $data_attr,
+                esc_html( $label )
+            );
+        }
+
+        $output .= '</ul>';
+
+        return $output;
+    }
+}
+
+if ( ! function_exists( 'mcd_render_post_categories' ) ) {
+    /**
+     * Render the category badges for a post.
+     *
+     * @param int $post_id Post ID.
+     * @return string
+     */
+    function mcd_render_post_categories( $post_id ) {
+        $categories = get_the_category( $post_id );
+
+        if ( empty( $categories ) || is_wp_error( $categories ) ) {
+            return '';
+        }
+
+        $badges = '';
+
+        foreach ( $categories as $category ) {
+            $link = get_term_link( $category );
+
+            if ( is_wp_error( $link ) ) {
+                continue;
+            }
+
+            $badges .= sprintf(
+                '<span class="post-category"><a class="post-category__link" href="%1$s">%2$s</a></span>',
+                esc_url( $link ),
+                esc_html( $category->name )
+            );
+        }
+
+        return $badges;
+    }
+}
+
+if ( ! function_exists( 'mcd_render_blog_archive_loop' ) ) {
+    /**
+     * Render callback for the blog archive loop block.
+     *
+     * @param array    $attributes Block attributes.
+     * @param string   $content    Block default content.
+     * @param WP_Block $block      Block instance.
+     * @return string
+     */
+    function mcd_render_blog_archive_loop( $attributes, $content, $block ) {
+        global $wp_query;
+
+        if ( ! $wp_query instanceof WP_Query ) {
+            return '';
+        }
+
+        $current_page = max( 1, (int) get_query_var( 'paged' ) );
+        if ( 1 === $current_page ) {
+            $page_number = (int) get_query_var( 'page' );
+            if ( $page_number > $current_page ) {
+                $current_page = $page_number;
+            }
+        }
+        $query_args   = $wp_query->query_vars;
+
+        $query_args['paged']           = $current_page;
+        $query_args['no_found_rows']   = false;
+        $query_args['posts_per_page']  = $wp_query->get( 'posts_per_page' );
+        $query_args['orderby']         = $wp_query->get( 'orderby' );
+        $query_args['order']           = $wp_query->get( 'order' );
+        $query_args['ignore_sticky_posts'] = $wp_query->get( 'ignore_sticky_posts' );
+
+        unset( $query_args['fields'] );
+
+        $loop = new WP_Query( $query_args );
+
+        if ( ! $loop->have_posts() ) {
+            ob_start();
+            ?>
+            <section class="category-filters" aria-label="<?php esc_attr_e( 'Category filters', 'mccullough-digital' ); ?>">
+                <div class="category-filters__inner">
+                    <?php echo mcd_render_category_pills(); ?>
+                </div>
+            </section>
+            <section class="blog-archive__loop container">
+                <div class="no-results not-found">
+                    <p><?php esc_html_e( 'It seems we can’t find what you’re looking for. Perhaps searching can help.', 'mccullough-digital' ); ?></p>
+                    <?php get_search_form(); ?>
+                </div>
+            </section>
+            <?php
+            $markup = ob_get_clean();
+            wp_reset_postdata();
+            return $markup;
+        }
+
+        $show_featured = ! is_paged();
+
+        ob_start();
+        ?>
+        <section class="category-filters" aria-label="<?php esc_attr_e( 'Category filters', 'mccullough-digital' ); ?>">
+            <div class="category-filters__inner">
+                <?php echo mcd_render_category_pills(); ?>
+            </div>
+        </section>
+        <?php
+
+        if ( $show_featured && $loop->have_posts() ) {
+            $loop->the_post();
+            $featured_id    = get_the_ID();
+            $featured_link  = get_permalink();
+            $featured_title = get_the_title();
+            $featured_date  = get_the_date( 'M j, Y' );
+            $featured_excerpt = wp_trim_words( get_the_excerpt(), 40, '…' );
+            $category_badges  = mcd_render_post_categories( $featured_id );
+            ?>
+            <section class="latest-post" aria-label="<?php esc_attr_e( 'Latest post', 'mccullough-digital' ); ?>">
+                <article class="latest-card">
+                    <?php if ( is_home() ) : ?>
+                        <span class="latest-badge"><?php esc_html_e( 'Most Recent', 'mccullough-digital' ); ?></span>
+                    <?php endif; ?>
+                    <div class="latest-inner">
+                        <a class="latest-media" href="<?php echo esc_url( $featured_link ); ?>">
+                            <?php
+                            if ( has_post_thumbnail( $featured_id ) ) {
+                                the_post_thumbnail( 'large', [ 'class' => 'latest-media__image' ] );
+                            } else {
+                                ?>
+                                <span class="latest-media__placeholder" aria-hidden="true">📰</span>
+                                <?php
+                            }
+                            ?>
+                        </a>
+                        <div class="latest-content">
+                            <div class="post-meta">
+                                <?php echo $category_badges; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                <span class="post-date"><?php echo esc_html( $featured_date ); ?></span>
+                            </div>
+                            <h2 class="latest-title"><a href="<?php echo esc_url( $featured_link ); ?>"><?php echo esc_html( $featured_title ); ?></a></h2>
+                            <?php if ( $featured_excerpt ) : ?>
+                                <p class="latest-excerpt"><?php echo esc_html( $featured_excerpt ); ?></p>
+                            <?php endif; ?>
+                            <div class="latest-actions">
+                                <a class="cta-button read-more" href="<?php echo esc_url( $featured_link ); ?>"><?php esc_html_e( 'Read Article', 'mccullough-digital' ); ?></a>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+            </section>
+            <?php
+        }
+
+        ?>
+        <section class="blog-archive__loop container" aria-label="<?php esc_attr_e( 'Blog posts', 'mccullough-digital' ); ?>">
+            <div class="post-grid">
+                <?php
+                $rendered_posts = 0;
+
+                while ( $loop->have_posts() ) {
+                    $loop->the_post();
+                    $post_id    = get_the_ID();
+                    $post_link  = get_permalink();
+                    $post_title = get_the_title();
+                    $post_date  = get_the_date( 'M j, Y' );
+                    $excerpt    = wp_trim_words( get_the_excerpt(), 28, '…' );
+                    $rendered_posts++;
+                    ?>
+                    <article class="post-card">
+                        <a class="post-card-image" href="<?php echo esc_url( $post_link ); ?>">
+                            <?php
+                            if ( has_post_thumbnail() ) {
+                                the_post_thumbnail( 'large', [ 'class' => 'post-card-image__media' ] );
+                            } else {
+                                ?>
+                                <span class="post-card-image__placeholder" aria-hidden="true">📰</span>
+                                <?php
+                            }
+                            ?>
+                        </a>
+                        <div class="post-card-content">
+                            <div class="post-meta">
+                                <?php echo mcd_render_post_categories( $post_id ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                <span class="post-date"><?php echo esc_html( $post_date ); ?></span>
+                            </div>
+                            <h2 class="post-card__title"><a href="<?php echo esc_url( $post_link ); ?>"><?php echo esc_html( $post_title ); ?></a></h2>
+                            <?php if ( $excerpt ) : ?>
+                                <p class="post-excerpt"><?php echo esc_html( $excerpt ); ?></p>
+                            <?php endif; ?>
+                            <div class="post-card-actions">
+                                <a class="cta-button read-more" href="<?php echo esc_url( $post_link ); ?>"><?php esc_html_e( 'Read More', 'mccullough-digital' ); ?></a>
+                            </div>
+                        </div>
+                    </article>
+                    <?php
+                }
+                ?>
+            </div>
+            <?php if ( 0 === $rendered_posts ) : ?>
+                <p class="post-grid__empty"><?php esc_html_e( 'No additional posts yet—check back soon for more stories.', 'mccullough-digital' ); ?></p>
+            <?php endif; ?>
+            <?php
+            $pagination_links = paginate_links(
+                [
+                    'total'     => max( 1, (int) $loop->max_num_pages ),
+                    'current'   => $current_page,
+                    'type'      => 'array',
+                    'prev_text' => __( '← Previous', 'mccullough-digital' ),
+                    'next_text' => __( 'Next →', 'mccullough-digital' ),
+                ]
+            );
+
+            if ( ! empty( $pagination_links ) ) {
+                echo '<nav class="pagination" aria-label="' . esc_attr__( 'Posts pagination', 'mccullough-digital' ) . '">';
+                foreach ( $pagination_links as $link ) {
+                    echo wp_kses_post( $link );
+                }
+                echo '</nav>';
+            }
+            ?>
+        </section>
+        <?php
+
+        wp_reset_postdata();
+
+        return ob_get_clean();
+    }
+}

--- a/bug-report.md
+++ b/bug-report.md
@@ -15,6 +15,11 @@ This report tracks all production-impacting fixes and continuous improvements in
    *Issue:* Every query loop rendered the “Most Recent” badge markup, leaving paged archives and secondary listings to mislabel older posts even when they were no longer the newest entry.
    *Resolution:* Introduced a `render_block` filter that suppresses the badge outside the main posts query’s first page, ensuring only the true latest article carries the highlight while documentation reflects the logic.
 
+3. **Blog Archive Loop Separation**
+   *Files:* `blocks/blog-archive-loop/block.json`, `blocks/blog-archive-loop/render.php`, `templates/index.html`, `templates/archive.html`, `templates/search.html`, `templates/404.html`, `patterns/post-card-grid.php`, `style.css`, `editor-style.css`, `AGENTS.md`, `bug-report.md`, `readme.txt`
+   *Issue:* The archive and index templates still depended on a single Query Loop with CSS hacks to style the first card, so the curated category pills, featured-post hero, and remaining grid could never match the mockup or respect pagination without duplicate markup.
+   *Resolution:* Registered a dynamic `mccullough-digital/blog-archive-loop` block that renders the pill navigation, standalone latest-post hero, remaining grid with empty-state messaging, and pagination; updated supporting templates and CSS (front end and editor) to consume the new layout and shared `.post-grid` class while trimming the post card pattern and syncing project docs.
+
 ### 2025-11-08 Sweep
 1. **Header Logo Sizing Clamp**
    *Files:* `style.css`, `editor-style.css`, `AGENTS.md`, `readme.txt`, `bug-report.md`

--- a/editor-style.css
+++ b/editor-style.css
@@ -898,7 +898,7 @@
     margin: 0;
 }
 
-.editor-styles-wrapper .category-filters__list a {
+.editor-styles-wrapper .category-pill {
     display: inline-flex;
     align-items: center;
     padding: 10px 25px;
@@ -912,20 +912,101 @@
     white-space: nowrap;
 }
 
-.editor-styles-wrapper .category-filters__list a:hover,
-.editor-styles-wrapper .category-filters__list li.current-cat > a,
-.editor-styles-wrapper .category-filters__list li.current-cat-parent > a,
-.editor-styles-wrapper .category-filters__list li.current-cat-ancestor > a {
+.editor-styles-wrapper .category-pill:hover,
+.editor-styles-wrapper .category-pill:focus-visible,
+.editor-styles-wrapper .category-pill.is-active {
     border-color: var(--neon-cyan);
     color: var(--neon-cyan);
     background: rgba(0, 229, 255, 0.1);
+    box-shadow: 0 0 15px rgba(0, 229, 255, 0.3);
+}
+
+.editor-styles-wrapper .latest-post {
+    padding: clamp(48px, 8vw, 72px) 5% 0;
+}
+
+.editor-styles-wrapper .latest-card {
+    position: relative;
+    background: var(--surface-dark);
+    border: 1px solid var(--surface-border);
+    border-radius: 18px;
+    overflow: hidden;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.editor-styles-wrapper .latest-inner {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+    align-items: stretch;
+}
+
+.editor-styles-wrapper .latest-media {
+    position: relative;
+    min-height: clamp(260px, 28vw, 320px);
+    background: linear-gradient(135deg, rgba(0, 229, 255, 0.25), rgba(255, 0, 224, 0.25));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.editor-styles-wrapper .latest-media__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.editor-styles-wrapper .latest-media__placeholder {
+    font-size: clamp(3rem, 6vw, 4.5rem);
+    color: rgba(230, 241, 255, 0.35);
+}
+
+.editor-styles-wrapper .latest-content {
+    padding: clamp(40px, 6vw, 56px);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(16px, 2vw, 20px);
+    justify-content: center;
+}
+
+.editor-styles-wrapper .latest-title {
+    font-family: 'Caveat', cursive;
+    font-size: clamp(2.4rem, 5vw, 3.1rem);
+    line-height: 1.1;
+    margin: 0;
+}
+
+.editor-styles-wrapper .latest-excerpt {
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.editor-styles-wrapper .latest-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.editor-styles-wrapper .latest-badge {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta));
+    color: var(--background-dark);
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
 }
 
 .editor-styles-wrapper .blog-archive__loop.container {
-    padding: clamp(64px, 9vw, 96px) 0 clamp(64px, 9vw, 96px);
+    padding: clamp(48px, 8vw, 80px) 5% clamp(64px, 9vw, 96px);
 }
 
-.editor-styles-wrapper .post-listing-grid {
+.editor-styles-wrapper .post-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: clamp(32px, 4vw, 48px);
@@ -933,11 +1014,12 @@
     margin-bottom: clamp(56px, 8vw, 80px);
 }
 
-.editor-styles-wrapper .post-listing-grid > article.post-card:first-child {
+.editor-styles-wrapper .post-grid__empty {
     grid-column: 1 / -1;
-    display: grid;
-    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
-    gap: 0;
+    text-align: center;
+    color: var(--text-secondary);
+    margin: clamp(24px, 6vw, 48px) auto;
+    max-width: 520px;
 }
 
 .editor-styles-wrapper .post-card {
@@ -951,25 +1033,6 @@
     min-height: 100%;
 }
 
-.editor-styles-wrapper .post-card p.latest-badge {
-    position: absolute;
-    top: 16px;
-    left: 16px;
-    margin: 0;
-    padding: 6px 14px;
-    border-radius: 999px;
-    background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta));
-    color: var(--background-dark);
-    font-size: 0.8rem;
-    font-weight: 800;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-}
-
-.editor-styles-wrapper .post-listing-grid > article.post-card:not(:first-child) p.latest-badge {
-    display: none;
-}
-
 .editor-styles-wrapper .post-card-image {
     position: relative;
     min-height: 220px;
@@ -980,14 +1043,16 @@
     overflow: hidden;
 }
 
-.editor-styles-wrapper .post-card-image .wp-block-post-featured-image,
-.editor-styles-wrapper .post-card-image .wp-block-post-featured-image figure,
-.editor-styles-wrapper .post-card-image .wp-block-post-featured-image a,
-.editor-styles-wrapper .post-card-image .wp-block-post-featured-image img {
+.editor-styles-wrapper .post-card-image__media {
     width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;
+}
+
+.editor-styles-wrapper .post-card-image__placeholder {
+    font-size: clamp(2.5rem, 5vw, 3.5rem);
+    color: rgba(230, 241, 255, 0.35);
 }
 
 .editor-styles-wrapper .post-card-content {
@@ -1008,8 +1073,6 @@
 
 .editor-styles-wrapper .post-meta .post-category {
     display: inline-flex;
-    gap: 8px;
-    flex-wrap: wrap;
 }
 
 .editor-styles-wrapper .post-meta .post-category a {
@@ -1022,6 +1085,11 @@
     color: var(--neon-cyan);
     font-size: 0.85rem;
     text-decoration: none;
+}
+
+.editor-styles-wrapper .post-meta .post-category a:hover,
+.editor-styles-wrapper .post-meta .post-category a:focus-visible {
+    background: rgba(0, 229, 255, 0.18);
 }
 
 .editor-styles-wrapper .post-meta .post-date {
@@ -1047,18 +1115,9 @@
     margin-top: auto;
 }
 
-.editor-styles-wrapper .post-card .wp-block-read-more.cta-button {
+.editor-styles-wrapper .post-card .cta-button.read-more {
     align-self: flex-start;
     margin-top: clamp(12px, 2vw, 18px);
-}
-
-.editor-styles-wrapper .post-listing-grid > article.post-card:first-child .post-card-image {
-    min-height: clamp(260px, 28vw, 320px);
-}
-
-.editor-styles-wrapper .post-listing-grid > article.post-card:first-child .post-card-content {
-    padding: clamp(40px, 6vw, 56px);
-    justify-content: center;
 }
 
 .editor-styles-wrapper .pagination {
@@ -1085,12 +1144,12 @@
 }
 
 @media (max-width: 900px) {
-    .editor-styles-wrapper .post-listing-grid > article.post-card:first-child {
+    .editor-styles-wrapper .latest-inner {
         grid-template-columns: 1fr;
     }
 
-    .editor-styles-wrapper .post-listing-grid > article.post-card:first-child .post-card-image {
-        min-height: 240px;
+    .editor-styles-wrapper .latest-media {
+        min-height: clamp(220px, 40vw, 280px);
     }
 }
 
@@ -1107,7 +1166,7 @@
         justify-content: flex-start;
     }
 
-    .editor-styles-wrapper .post-listing-grid {
+    .editor-styles-wrapper .post-grid {
         grid-template-columns: 1fr;
     }
 }

--- a/patterns/post-card-grid.php
+++ b/patterns/post-card-grid.php
@@ -8,10 +8,6 @@
  */
 ?>
 <!-- wp:group {"tagName":"article","className":"post-card"} -->
-    <!-- wp:paragraph {"className":"latest-badge"} -->
-    Most Recent
-    <!-- /wp:paragraph -->
-
     <!-- wp:group {"className":"post-card-image","layout":{"type":"constrained"}} -->
         <!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9"} /-->
     <!-- /wp:group -->

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,7 @@ This theme does not have any widget areas registered by default.
 * **Neon Blog Archive Template:** Rebuilt the archive and index templates around a radial hero, live search, pill-style category filters, and a featured post grid with matching editor styles so the blog listing mirrors the new mockup without duplicating markup in patterns.
 * **Blog Hero Glitch Parity:** Extended the header enhancement script and blog hero styles so the archive title now splits into interactive glitch letters with proper reduced-motion fallbacks, matching the front-page hero treatment.
 * **Latest Badge Query Guard:** Limited the “Most Recent” badge to the main posts query on its first page, preventing paged archives and secondary loops from mislabeling older entries while keeping the grid markup clean elsewhere.
+* **Blog Archive Loop Block:** Registered a `mccullough-digital/blog-archive-loop` dynamic block that renders curated category pills, a dedicated latest-post hero, the remaining `.post-grid` layout, and empty-state messaging with synchronized front-end/editor styling.
 
 = 1.2.38 - 2025-11-06 =
 * **Hero CTA Alignment Controls:** Freed the hero wrapper overflow and centring overrides so the neon button's URL popover opens fully while align and spacing controls can park the CTA left, centre, or right with extra breathing room.

--- a/style.css
+++ b/style.css
@@ -1233,7 +1233,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     margin: 0;
 }
 
-.category-filters__list a {
+.category-pill {
     display: inline-flex;
     align-items: center;
     padding: 10px 25px;
@@ -1247,21 +1247,119 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     white-space: nowrap;
 }
 
-.category-filters__list a:hover,
-.category-filters__list li.current-cat > a,
-.category-filters__list li.current-cat-parent > a,
-.category-filters__list li.current-cat-ancestor > a {
+.category-pill:hover,
+.category-pill:focus-visible,
+.category-pill.is-active {
     border-color: var(--neon-cyan);
     color: var(--neon-cyan);
     background: rgba(0, 229, 255, 0.1);
     box-shadow: 0 0 15px rgba(0, 229, 255, 0.3);
 }
 
-.blog-archive__loop.container {
-    padding: clamp(64px, 9vw, 96px) 0 clamp(64px, 9vw, 96px);
+.latest-post {
+    padding: clamp(48px, 8vw, 72px) 5% 0;
 }
 
-.post-listing-grid {
+.latest-card {
+    position: relative;
+    background: var(--surface-dark);
+    border: 1px solid var(--surface-border);
+    border-radius: 18px;
+    overflow: hidden;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.latest-card:hover {
+    border-color: var(--neon-cyan);
+    box-shadow: 0 15px 45px rgba(0, 229, 255, 0.25);
+    transform: translateY(-6px);
+}
+
+.latest-inner {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+    align-items: stretch;
+}
+
+.latest-media {
+    position: relative;
+    min-height: clamp(260px, 28vw, 320px);
+    background: linear-gradient(135deg, rgba(0, 229, 255, 0.25), rgba(255, 0, 224, 0.25));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.latest-media__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.latest-media__placeholder {
+    font-size: clamp(3rem, 6vw, 4.5rem);
+    color: rgba(230, 241, 255, 0.35);
+}
+
+.latest-content {
+    padding: clamp(40px, 6vw, 56px);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(16px, 2vw, 20px);
+    justify-content: center;
+}
+
+.latest-title {
+    font-family: 'Caveat', cursive;
+    font-size: clamp(2.4rem, 5vw, 3.1rem);
+    line-height: 1.1;
+    margin: 0;
+}
+
+.latest-title a {
+    color: var(--text-primary);
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.latest-title a:hover {
+    color: var(--neon-cyan);
+}
+
+.latest-excerpt {
+    color: var(--text-secondary);
+    margin: 0;
+    line-height: 1.7;
+}
+
+.latest-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.latest-badge {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta));
+    color: var(--background-dark);
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    box-shadow: 0 12px 30px rgba(0, 229, 255, 0.35);
+}
+
+.blog-archive__loop.container {
+    padding: clamp(48px, 8vw, 80px) 5% clamp(64px, 9vw, 96px);
+}
+
+.post-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: clamp(32px, 4vw, 48px);
@@ -1269,11 +1367,12 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     margin-bottom: clamp(56px, 8vw, 80px);
 }
 
-.post-listing-grid > article.post-card:first-child {
+.post-grid__empty {
     grid-column: 1 / -1;
-    display: grid;
-    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
-    gap: 0;
+    text-align: center;
+    color: var(--text-secondary);
+    margin: clamp(24px, 6vw, 48px) auto;
+    max-width: 520px;
 }
 
 .post-card {
@@ -1294,26 +1393,6 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     box-shadow: 0 10px 40px rgba(0, 229, 255, 0.2);
 }
 
-.post-card p.latest-badge {
-    position: absolute;
-    top: 16px;
-    left: 16px;
-    margin: 0;
-    padding: 6px 14px;
-    border-radius: 999px;
-    background: linear-gradient(120deg, var(--neon-cyan), var(--neon-magenta));
-    color: var(--background-dark);
-    font-size: 0.8rem;
-    font-weight: 800;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
-    box-shadow: 0 10px 25px rgba(0, 229, 255, 0.35);
-}
-
-.post-listing-grid > article.post-card:not(:first-child) p.latest-badge {
-    display: none;
-}
-
 .post-card-image {
     position: relative;
     min-height: 220px;
@@ -1324,14 +1403,16 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     overflow: hidden;
 }
 
-.post-card-image .wp-block-post-featured-image,
-.post-card-image .wp-block-post-featured-image figure,
-.post-card-image .wp-block-post-featured-image a,
-.post-card-image .wp-block-post-featured-image img {
+.post-card-image__media {
     width: 100%;
     height: 100%;
     object-fit: cover;
     display: block;
+}
+
+.post-card-image__placeholder {
+    font-size: clamp(2.5rem, 5vw, 3.5rem);
+    color: rgba(230, 241, 255, 0.35);
 }
 
 .post-card-content {
@@ -1352,8 +1433,6 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 
 .post-meta .post-category {
     display: inline-flex;
-    gap: 8px;
-    flex-wrap: wrap;
 }
 
 .post-meta .post-category a {
@@ -1369,7 +1448,8 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     transition: all 0.3s ease;
 }
 
-.post-meta .post-category a:hover {
+.post-meta .post-category a:hover,
+.post-meta .post-category a:focus-visible {
     background: rgba(0, 229, 255, 0.18);
     box-shadow: 0 0 15px rgba(0, 229, 255, 0.3);
 }
@@ -1407,18 +1487,9 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
     margin-top: auto;
 }
 
-.post-card .wp-block-read-more.cta-button {
+.post-card .cta-button.read-more {
     align-self: flex-start;
     margin-top: clamp(12px, 2vw, 18px);
-}
-
-.post-listing-grid > article.post-card:first-child .post-card-image {
-    min-height: clamp(260px, 28vw, 320px);
-}
-
-.post-listing-grid > article.post-card:first-child .post-card-content {
-    padding: clamp(40px, 6vw, 56px);
-    justify-content: center;
 }
 
 .pagination {
@@ -1459,12 +1530,12 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 }
 
 @media (max-width: 900px) {
-    .post-listing-grid > article.post-card:first-child {
+    .latest-inner {
         grid-template-columns: 1fr;
     }
 
-    .post-listing-grid > article.post-card:first-child .post-card-image {
-        min-height: 240px;
+    .latest-media {
+        min-height: clamp(220px, 40vw, 280px);
     }
 }
 
@@ -1485,7 +1556,7 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
         justify-content: flex-start;
     }
 
-    .post-listing-grid {
+    .post-grid {
         grid-template-columns: 1fr;
     }
 }

--- a/templates/404.html
+++ b/templates/404.html
@@ -17,7 +17,7 @@
   <!-- /wp:group -->
 
   <!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false}} -->
-    <!-- wp:post-template {"tagName":"div","className":"post-listing-grid"} -->
+      <!-- wp:post-template {"tagName":"div","className":"post-grid"} -->
       <!-- wp:pattern {"slug":"mccullough-digital/post-card"} /-->
     <!-- /wp:post-template -->
   <!-- /wp:query -->

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -15,35 +15,9 @@
                 <!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search articles...","buttonText":"Search","buttonUseIcon":false,"className":"blog-search"} /-->
             <!-- /wp:group -->
         <!-- /wp:group -->
-
-        <!-- wp:group {"className":"category-filters","layout":{"type":"constrained"}} -->
-            <!-- wp:group {"className":"category-filters__inner","layout":{"type":"flex","justifyContent":"center","orientation":"horizontal","flexWrap":"wrap"}} -->
-                <!-- wp:categories {"showHierarchy":false,"showPostCounts":false,"className":"category-filters__list"} /-->
-            <!-- /wp:group -->
-        <!-- /wp:group -->
-
-        <!-- wp:group {"className":"blog-archive__loop container","layout":{"type":"constrained"}} -->
-            <!-- wp:post-template {"tagName":"div","className":"post-listing-grid"} -->
-                <!-- wp:pattern {"slug":"mccullough-digital/post-card"} /-->
-            <!-- /wp:post-template -->
-
-            <!-- wp:query-no-results -->
-                <!-- wp:group {"className":"no-results not-found","layout":{"type":"constrained"}} -->
-                    <!-- wp:paragraph -->
-                    <p>It seems we can’t find what you’re looking for. Perhaps searching can help.</p>
-                    <!-- /wp:paragraph -->
-
-                    <!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search articles...","buttonText":"Search","buttonUseIcon":false,"className":"blog-search"} /-->
-                <!-- /wp:group -->
-            <!-- /wp:query-no-results -->
-
-            <!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"className":"pagination"} -->
-                <!-- wp:query-pagination-previous /-->
-                <!-- wp:query-pagination-numbers /-->
-                <!-- wp:query-pagination-next /-->
-            <!-- /wp:query-pagination -->
-        <!-- /wp:group -->
     <!-- /wp:query -->
+
+    <!-- wp:mccullough-digital/blog-archive-loop /-->
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer-neon","tagName":"footer"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,35 +15,9 @@
                 <!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search articles...","buttonText":"Search","buttonUseIcon":false,"className":"blog-search"} /-->
             <!-- /wp:group -->
         <!-- /wp:group -->
-
-        <!-- wp:group {"className":"category-filters","layout":{"type":"constrained"}} -->
-            <!-- wp:group {"className":"category-filters__inner","layout":{"type":"flex","justifyContent":"center","orientation":"horizontal","flexWrap":"wrap"}} -->
-                <!-- wp:categories {"showHierarchy":false,"showPostCounts":false,"className":"category-filters__list"} /-->
-            <!-- /wp:group -->
-        <!-- /wp:group -->
-
-        <!-- wp:group {"className":"blog-archive__loop container","layout":{"type":"constrained"}} -->
-            <!-- wp:post-template {"tagName":"div","className":"post-listing-grid"} -->
-                <!-- wp:pattern {"slug":"mccullough-digital/post-card"} /-->
-            <!-- /wp:post-template -->
-
-            <!-- wp:query-no-results -->
-                <!-- wp:group {"className":"no-results not-found","layout":{"type":"constrained"}} -->
-                    <!-- wp:paragraph -->
-                    <p>It seems we can’t find what you’re looking for. Perhaps searching can help.</p>
-                    <!-- /wp:paragraph -->
-
-                    <!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search articles...","buttonText":"Search","buttonUseIcon":false,"className":"blog-search"} /-->
-                <!-- /wp:group -->
-            <!-- /wp:query-no-results -->
-
-            <!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"className":"pagination"} -->
-                <!-- wp:query-pagination-previous /-->
-                <!-- wp:query-pagination-numbers /-->
-                <!-- wp:query-pagination-next /-->
-            <!-- /wp:query-pagination -->
-        <!-- /wp:group -->
     <!-- /wp:query -->
+
+    <!-- wp:mccullough-digital/blog-archive-loop /-->
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer-neon","tagName":"footer"} /-->

--- a/templates/search.html
+++ b/templates/search.html
@@ -9,7 +9,7 @@
         <!-- /wp:group -->
 
         <!-- wp:group {"className":"container","layout":{"type":"constrained"}} -->
-            <!-- wp:post-template {"tagName":"div","className":"post-listing-grid"} -->
+            <!-- wp:post-template {"tagName":"div","className":"post-grid"} -->
                 <!-- wp:pattern {"slug":"mccullough-digital/post-card"} /-->
             <!-- /wp:post-template -->
 


### PR DESCRIPTION
## Summary
- add a server-rendered `mccullough-digital/blog-archive-loop` block that renders the curated category pills, latest-post hero, grid, and pagination
- switch the blog, archive, search, and 404 templates over to the new loop and shared `.post-grid` markup while trimming the post card pattern
- refresh front-end/editor styling for the hero, pill navigation, grid, and empty states and document the update across project notes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddf25cfcf48324a5ae2b6d0ad50155