### PR TITLE
Fix blog archive header offset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@ This repository contains the McCullough Digital block theme. The notes below sum
 - **Server Preview:** Added an editor-only script that registers `mccullough-digital/blog-archive-loop` with `ServerSideRender` so the Site Editor mirrors the PHP output without unsupported notices.
 - **Inserter Guard:** Kept the block template-only by disabling the inserter while bundling the new script through the build pipeline for automatic enqueueing.
 - **Docs Synced:** Recorded the block preview and inserter guard updates across `AGENTS.md`, `bug-report.md`, and `readme.txt` per repository guidelines.
+-### Latest (2025-11-11) - Blog Hero Header Offset
+- **Archive Offset Restored:** Reinstated the `.site-content.blog-archive` padding so the blog listing respects the fixed header offset token instead of zeroing it out.
+- **Hero Padding Clamp:** Trimmed the `.blog-hero` top padding to a simple clamp, letting the wrapper supply the masthead offset while keeping the intended breathing room.
+- **Build & Docs:** Rebuilt theme assets via `npm run build` and logged the offset correction in `bug-report.md` and `readme.txt`.
 -### Latest (2025-11-10) - Blog Archive Loop Block
 - **Dynamic Loop:** Added a `mccullough-digital/blog-archive-loop` server-rendered block that outputs the curated category pills, a standalone latest-post hero, the remaining grid, and pagination while respecting the active archive context.
 - **Markup Cleanup:** Replaced the template-level Query Loop with the new block in `templates/index.html` and `templates/archive.html`, updated search/404 templates to the shared `.post-grid` class, and trimmed the post-card pattern so badges are exclusive to the featured hero.

--- a/bug-report.md
+++ b/bug-report.md
@@ -9,6 +9,10 @@ This report tracks all production-impacting fixes and continuous improvements in
    *Files:* `blocks/blog-archive-loop/editor.js`, `blocks/blog-archive-loop/block.json`, `build/blocks/blog-archive-loop/editor.js`, `build/blocks/blog-archive-loop/editor.asset.php`
    *Issue:* The dynamic loop block lacked an editor script, causing the Site Editor to flag it as unsupported and hide the PHP-rendered layout while authors curated the Blog Home template.
    *Resolution:* Registered the block inside a new editor bundle that leverages `ServerSideRender` for previews, hid the block from the inserter to keep it template-only, and rebuilt production assets so the Site Editor now mirrors the front end without warnings.
+2. **Blog Archive Header Offset Regression**
+   *Files:* `style.css`, `AGENTS.md`, `bug-report.md`, `readme.txt`
+   *Issue:* The blog archive wrapper removed the fixed-header padding, and the hero doubled the offset via an extra `calc()`, leaving the masthead covering the top of the hero while adding excess space above the content.
+   *Resolution:* Restored the `.site-content.blog-archive` padding to consume the header offset token, simplified the hero's top padding to a clamp-only value, rebuilt theme assets, and documented the fix across project notes.
 
 ### 2025-11-09 Sweep
 1. **Blog Hero Glitch Parity**

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,7 @@ This theme does not have any widget areas registered by default.
 == Changelog ==
 
 = 1.2.39 - Unreleased =
+* **Blog Hero Offset Correction:** Restored the blog archive header padding and simplified the hero's top spacing so the masthead no longer overlaps the hero while retaining the intended breathing room.
 * **Blog Archive Loop Preview:** Added an editor bundle that registers the dynamic loop block with `ServerSideRender`, hides it from the inserter, and ensures the Site Editor Blog Home template renders the PHP layout without unsupported notices.
 * **Header Logo Clamp:** Scoped the masthead logo styling to outrank WordPress core selectors and added max constraints so oversize uploads respect `--logo-size-header` without inflating the fixed header or Site Editor preview.
 * **Neon Blog Archive Template:** Rebuilt the archive and index templates around a radial hero, live search, pill-style category filters, and a featured post grid with matching editor styles so the blog listing mirrors the new mockup without duplicating markup in patterns.

--- a/style.css
+++ b/style.css
@@ -1041,13 +1041,13 @@ main.site-content { padding-top: var(--mcd-header-offset, var(--header-height));
 
 /* --- Blog Template --- */
 .site-content.blog-archive {
-    padding-top: 0;
+    padding-top: var(--mcd-header-offset, var(--header-height));
 }
 
 .blog-hero {
     position: relative;
     overflow: hidden;
-    padding: calc(var(--mcd-header-offset, var(--header-height)) + clamp(72px, 12vw, 140px)) 5% clamp(72px, 9vw, 120px);
+    padding: clamp(72px, 12vw, 140px) 5% clamp(72px, 9vw, 120px);
     background: radial-gradient(circle at 50% 30%, rgba(0, 229, 255, 0.15), transparent 60%),
         radial-gradient(circle at 80% 70%, rgba(255, 0, 224, 0.12), transparent 55%),
         var(--background-dark);


### PR DESCRIPTION
## Summary
- restore the blog archive wrapper padding so the fixed masthead offset is respected again
- simplify the blog hero top padding clamp to avoid doubling the header offset
- document the regression fix across AGENTS.md, bug-report.md, and readme.txt

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de8d44826c8324bc00d6012a6dde6a