### PR TITLE
Adjust masthead fallback offset for blog hero

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ This repository contains the McCullough Digital block theme. The notes below sum
 4. **Always** update `AGENTS.md`, `bug-report.md`, and `readme.txt` to reflect any bug fixes or improvements.
 
 ## Bug Fix & Improvement Highlights
+-### Latest (2025-11-12) - Masthead Fallback Offset
+- **Fallback Raised:** Increased the root `--header-height` token to 100px so pages maintain adequate scroll buffer beneath the fixed masthead even before JavaScript recalculates `--mcd-header-offset`.
+- **Parity Everywhere:** Mirrored the 100px fallback across `style.css`, `editor-style.css`, and `standalone.html` to keep the Site Editor, front end, and static preview aligned when scripts are disabled.
+- **Docs Synced:** Logged the fallback adjustment across `AGENTS.md`, `bug-report.md`, and `readme.txt` per repository guidelines.
 -### Latest (2025-11-11) - Blog Archive Loop Editor Preview
 - **Server Preview:** Added an editor-only script that registers `mccullough-digital/blog-archive-loop` with `ServerSideRender` so the Site Editor mirrors the PHP output without unsupported notices.
 - **Inserter Guard:** Kept the block template-only by disabling the inserter while bundling the new script through the build pipeline for automatic enqueueing.

--- a/bug-report.md
+++ b/bug-report.md
@@ -4,6 +4,12 @@ This report tracks all production-impacting fixes and continuous improvements in
 
 ## Fixed Bugs
 
+### 2025-11-12 Sweep
+1. **Masthead Fallback Offset Raised**
+   *Files:* `style.css`, `editor-style.css`, `standalone.html`, `AGENTS.md`, `bug-report.md`, `readme.txt`
+   *Issue:* Pages still lost the top of the blog hero when scripts failed to patch `--mcd-header-offset` because the fallback `--header-height` remained at 80px despite the masthead rendering closer to 100px tall.
+   *Resolution:* Increased the root `--header-height` token to 100px across the front-end, editor, and standalone bundles so the fixed header clears content before JavaScript runs, and documented the safeguard throughout project notes.
+
 ### 2025-11-11 Sweep
 1. **Blog Archive Loop Editor Preview**
    *Files:* `blocks/blog-archive-loop/editor.js`, `blocks/blog-archive-loop/block.json`, `build/blocks/blog-archive-loop/editor.js`, `build/blocks/blog-archive-loop/editor.asset.php`

--- a/editor-style.css
+++ b/editor-style.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@700&family=Nunito:wght@300;400;700&display=swap');
 
 :root {
-    --header-height: 80px;
+    --header-height: 100px;
     --mcd-header-offset: var(--header-height);
     --neon-cyan: #00e5ff;
     --neon-magenta: #ff00e0;

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,7 @@ This theme does not have any widget areas registered by default.
 == Changelog ==
 
 = 1.2.39 - Unreleased =
+* **Header Offset Fallback Raised:** Increased the root `--header-height` token to 100px across front-end, editor, and standalone bundles so pages clear the fixed masthead even when header scripts fail.
 * **Blog Hero Offset Correction:** Restored the blog archive header padding and simplified the hero's top spacing so the masthead no longer overlaps the hero while retaining the intended breathing room.
 * **Blog Archive Loop Preview:** Added an editor bundle that registers the dynamic loop block with `ServerSideRender`, hides it from the inserter, and ensures the Site Editor Blog Home template renders the PHP layout without unsupported notices.
 * **Header Logo Clamp:** Scoped the masthead logo styling to outrank WordPress core selectors and added max constraints so oversize uploads respect `--logo-size-header` without inflating the fixed header or Site Editor preview.

--- a/standalone.html
+++ b/standalone.html
@@ -29,7 +29,7 @@
         
         /* --- Variables --- */
         :root {
-            --header-height: 80px;
+            --header-height: 100px;
             --mcd-header-offset: var(--header-height);
             /* New Softer Palette */
             --neon-cyan: #00e5ff;

--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ Text Domain:   mccullough-digital
 
 /* --- Variables --- */
 :root {
-    --header-height: 80px;
+    --header-height: 100px;
     --mcd-header-offset: var(--header-height);
     /* New Softer Palette */
     --neon-cyan: #00e5ff;


### PR DESCRIPTION
## Summary
- raise the shared `--header-height` fallback to 100px so pages clear the fixed masthead when scripts do not run
- mirror the updated fallback in the editor stylesheet and standalone preview for consistent layout coverage
- document the masthead fallback safeguard across project notes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de8c0b686c8324a1175e09d9276396