### PR TITLE
Ensure hero fallback reuses neon button default label

### DIFF
--- a/blocks/button/render.php
+++ b/blocks/button/render.php
@@ -9,49 +9,21 @@
  * @package McCullough_Digital
  */
 
-// Debug: Log what we're receiving (remove this after debugging)
-if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-    error_log( 'Button Block Attributes: ' . print_r( $attributes, true ) );
-}
-
 $admin_debug_comment = '';
 $button_text         = isset( $attributes['buttonText'] ) ? trim( wp_strip_all_tags( (string) $attributes['buttonText'] ) ) : '';
 $button_link = isset( $attributes['buttonLink'] ) ? trim( (string) $attributes['buttonLink'] ) : '';
 $open_new_tab = isset( $attributes['opensInNewTab'] ) ? (bool) $attributes['opensInNewTab'] : false;
 
 if ( '' === $button_text ) {
-    $default_button_text = '';
-
-    if ( class_exists( 'WP_Block_Type_Registry' ) ) {
-        $block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'mccullough-digital/button' );
-
-        if ( $block_type && isset( $block_type->attributes['buttonText']['default'] ) ) {
-            $default_button_text = trim( wp_strip_all_tags( (string) $block_type->attributes['buttonText']['default'] ) );
-        }
+    if ( function_exists( 'mcd_get_neon_button_default_label' ) ) {
+        $button_text = mcd_get_neon_button_default_label();
     }
 
-    if ( '' === $default_button_text ) {
-        $block_metadata_path = trailingslashit( __DIR__ ) . 'block.json';
-
-        if ( file_exists( $block_metadata_path ) ) {
-            if ( function_exists( 'wp_json_file_decode' ) ) {
-                $metadata = wp_json_file_decode( $block_metadata_path, array( 'associative' => true ) );
-                if ( is_wp_error( $metadata ) ) {
-                    $metadata = null;
-                }
-            } else {
-                $metadata = json_decode( file_get_contents( $block_metadata_path ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions
-            }
-
-            if ( is_array( $metadata ) && isset( $metadata['attributes']['buttonText']['default'] ) ) {
-                $default_button_text = trim( wp_strip_all_tags( (string) $metadata['attributes']['buttonText']['default'] ) );
-            }
-        }
+    if ( '' === $button_text ) {
+        $button_text = __( 'Start a Project', 'mccullough-digital' );
     }
 
-    if ( '' !== $default_button_text ) {
-        $button_text = $default_button_text;
-    } elseif ( defined( 'WP_DEBUG' ) && WP_DEBUG && current_user_can( 'manage_options' ) ) {
+    if ( '' === $button_text && defined( 'WP_DEBUG' ) && WP_DEBUG && current_user_can( 'manage_options' ) ) {
         $admin_debug_comment = '<!-- Neon Button Block: No buttonText attribute received -->';
     }
 }

--- a/blocks/hero/render.php
+++ b/blocks/hero/render.php
@@ -71,6 +71,14 @@ if ( '' === $inner_content ) {
     $raw_link    = isset( $attributes['buttonLink'] ) ? trim( (string) $attributes['buttonLink'] ) : '';
     $button_link = '' !== $raw_link ? esc_url( $raw_link ) : '';
 
+    if ( '' === $button_text && function_exists( 'mcd_get_neon_button_default_label' ) ) {
+        $button_text = mcd_get_neon_button_default_label();
+    }
+
+    if ( '' === $button_text ) {
+        $button_text = __( 'Start a Project', 'mccullough-digital' );
+    }
+
     if ( '' !== $button_text ) {
         $button_label = sprintf(
             '<span class="hero__cta-button-label">%s</span>',

--- a/bug-report.md
+++ b/bug-report.md
@@ -11,6 +11,9 @@ This rolling QA log tracks production-impacting fixes and follow-up checks for t
 - Focus areas: fixed masthead offsets, blog archive loop experience, reusable neon CTA components.
 
 ## Recent Sweeps (November 2025)
+- **2025-11-15 — Hero fallback neon CTA label**
+  - Result: Hero block PHP fallback now pulls the neon button's metadata default when the saved label is blank, so legacy hero content and cached renders surface the CTA with "Start a Project" even before inner blocks resave.
+  - Follow-up: Confirm after translating the default label or when patterns change their seeded CTA copy.
 - **2025-11-14 — Neon button editor regression sweep**
   - Result: Editor now keeps the neon button clickable without leaving the editor when a link is set, and it restores the default "Start a Project" label whenever previously saved buttons load with an empty attribute.
   - Follow-up: Re-check after translating the default label or updating block editor RichText behaviour around empty strings.

--- a/functions.php
+++ b/functions.php
@@ -490,3 +490,55 @@ function mcd_debug_template() {
     }
 }
 add_action( 'wp_footer', 'mcd_debug_template' );
+
+if ( ! function_exists( 'mcd_get_neon_button_default_label' ) ) {
+    /**
+     * Retrieve the default neon button label from the block definition.
+     *
+     * @return string
+     */
+    function mcd_get_neon_button_default_label() {
+        static $cached_default = null;
+
+        if ( null !== $cached_default ) {
+            return $cached_default;
+        }
+
+        $default_label = '';
+
+        if ( class_exists( 'WP_Block_Type_Registry' ) ) {
+            $block_type = WP_Block_Type_Registry::get_instance()->get_registered( 'mccullough-digital/button' );
+
+            if ( $block_type && isset( $block_type->attributes['buttonText']['default'] ) ) {
+                $default_label = trim( wp_strip_all_tags( (string) $block_type->attributes['buttonText']['default'] ) );
+            }
+        }
+
+        if ( '' === $default_label ) {
+            $block_metadata_path = trailingslashit( get_stylesheet_directory() ) . 'blocks/button/block.json';
+
+            if ( file_exists( $block_metadata_path ) ) {
+                if ( function_exists( 'wp_json_file_decode' ) ) {
+                    $metadata = wp_json_file_decode( $block_metadata_path, array( 'associative' => true ) );
+                    if ( is_wp_error( $metadata ) ) {
+                        $metadata = null;
+                    }
+                } else {
+                    $metadata = json_decode( file_get_contents( $block_metadata_path ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+                }
+
+                if ( is_array( $metadata ) && isset( $metadata['attributes']['buttonText']['default'] ) ) {
+                    $default_label = trim( wp_strip_all_tags( (string) $metadata['attributes']['buttonText']['default'] ) );
+                }
+            }
+        }
+
+        if ( '' === $default_label ) {
+            $default_label = __( 'Start a Project', 'mccullough-digital' );
+        }
+
+        $cached_default = $default_label;
+
+        return $cached_default;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15544,6 +15544,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plur": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",

--- a/readme.txt
+++ b/readme.txt
@@ -49,7 +49,7 @@ This theme does not have any widget areas registered by default.
 * **Blog Hero Glitch Parity:** Extended the header enhancement script and blog hero styles so the archive title now splits into interactive glitch letters with proper reduced-motion fallbacks, matching the front-page hero treatment.
 * **Latest Badge Query Guard:** Limited the “Most Recent” badge to the main posts query on its first page, preventing paged archives and secondary loops from mislabeling older entries while keeping the grid markup clean elsewhere.
 * **Blog Archive Loop Block:** Registered a `mccullough-digital/blog-archive-loop` dynamic block that renders curated category pills, a dedicated latest-post hero, the remaining `.post-grid` layout, and empty-state messaging with synchronized front-end/editor styling.
-* **Neon Button Default Label Fallback:** Updated the neon button render callback to pull the block metadata default whenever the saved label is empty, keeping the CTA visible on published pages.
+* **Neon Button Default Label Fallback:** Updated the neon button render callback and hero PHP fallback to pull the block metadata default whenever the saved label is empty, keeping the CTA visible on published pages and in legacy hero content.
 * **Neon Button Editor Link Guard:** Prevented the neon button's editor preview from following its stored URL so authors can continue editing after adding a link.
 * **Neon Button Default Label Restore (Editor):** Backfilled the button text attribute with the block's default label whenever it loads empty so the Site Editor always shows editable copy.
 


### PR DESCRIPTION
## Summary
- add a shared helper that reads the neon button default label from the block registration metadata
- update the button render callback and hero PHP fallback to backfill the default label when saved content is empty
- document the fix in the changelog and QA log, and rebuild block assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df51cb95608324a762367b3d7c586e