### PR TITLE
Streamline neon footer layout

### DIFF
--- a/bug-report.md
+++ b/bug-report.md
@@ -11,6 +11,9 @@ This rolling QA log tracks production-impacting fixes and follow-up checks for t
 - Focus areas: fixed masthead offsets, blog archive loop experience, reusable neon CTA components.
 
 ## Recent Sweeps (November 2025)
+- **2025-11-18 — Footer Plan A streamlining**
+  - Result: Removed the hero-style headline from the neon footer, rebuilt the layout into balanced company, quick links, and connect columns, and synced editor/front-end styles for the slimmer structure.
+  - Follow-up: Re-test footer navigation hover/focus states after the next design polish pass and confirm the contact list adapts if a phone number is added.
 - **2025-11-17 — About slug helper + mobile nav + archive polish**
   - Result: Added an `mcd_get_about_page_url()` helper so the home CTA and neon footer follow renamed About pages, restored the core navigation responsive toggles on ≤768px screens, aligned blog card thumbnails to a 16:9 frame, and expanded service card CTAs to 44px touch targets.
   - Follow-up: Confirm translations extend the About helper candidate lists and re-test the hamburger toggle after future header layout tweaks.

--- a/editor-style.css
+++ b/editor-style.css
@@ -451,37 +451,6 @@
     z-index: var(--z-index-default);
 }
 
-.editor-styles-wrapper .footer-headline {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 12px;
-    text-align: center;
-}
-
-.editor-styles-wrapper .footer-eyebrow {
-    margin: 0;
-    text-transform: uppercase;
-    letter-spacing: 0.32em;
-    font-size: 0.75rem;
-    color: rgba(230, 241, 255, 0.7);
-}
-
-.editor-styles-wrapper .footer-headline__title {
-    margin: 0;
-    font-family: 'Caveat', cursive;
-    font-size: clamp(2.2rem, 6vw, 3.6rem);
-    color: var(--text-primary);
-    text-shadow: 0 0 14px rgba(0, 229, 255, 0.5), 0 0 26px rgba(255, 0, 224, 0.35);
-}
-
-.editor-styles-wrapper .footer-headline__description {
-    margin: 0;
-    max-width: 640px;
-    font-size: clamp(1rem, 2.2vw, 1.25rem);
-    color: rgba(214, 231, 255, 0.85);
-}
-
 .editor-styles-wrapper .wp-block-separator.footer-separator {
     margin: 0;
     border: none;
@@ -490,46 +459,32 @@
     opacity: 0.45;
 }
 
-.editor-styles-wrapper .footer-nav a,
-.editor-styles-wrapper .footer-contact a {
+.editor-styles-wrapper .footer-core a {
     outline: 2px solid var(--neon-cyan);
     outline-offset: 4px;
 }
 
 .editor-styles-wrapper .footer-core {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: clamp(24px, 5vw, 48px);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(24px, 4vw, 48px);
     align-items: start;
 }
 
-.editor-styles-wrapper .footer-branding,
-.editor-styles-wrapper .footer-links,
-.editor-styles-wrapper .footer-social,
-.editor-styles-wrapper .footer-contact {
+.editor-styles-wrapper .footer-column {
     display: flex;
     flex-direction: column;
     gap: 16px;
     align-items: flex-start;
 }
 
-.editor-styles-wrapper .footer-branding .wp-block-site-logo {
+.editor-styles-wrapper .footer-links {
+    gap: 20px;
+}
+
+.editor-styles-wrapper .footer-company .wp-block-site-logo {
     display: flex;
     justify-content: flex-start;
-}
-
-.editor-styles-wrapper .footer-branding .custom-logo {
-    height: auto;
-    width: auto;
-    max-height: var(--logo-size-footer);
-}
-
-.editor-styles-wrapper .footer-branding .wp-block-site-title {
-    font-family: 'Caveat', cursive;
-    font-size: clamp(2.2rem, 6vw, 3.2rem);
-    color: var(--text-primary);
-    margin: 0;
-    text-shadow: 0 0 12px rgba(0, 229, 255, 0.4);
 }
 
 .editor-styles-wrapper .footer-tagline {
@@ -537,6 +492,25 @@
     color: var(--text-secondary);
     margin: 0;
     max-width: 320px;
+}
+
+.editor-styles-wrapper .footer-connect {
+    gap: 20px;
+}
+
+.editor-styles-wrapper .footer-connect__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.editor-styles-wrapper .footer-connect__list a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 600;
 }
 
 .editor-styles-wrapper .footer-section-title {
@@ -563,14 +537,14 @@
     font-weight: 600;
 }
 
-.editor-styles-wrapper .social-links-menu {
-    gap: 18px;
+.editor-styles-wrapper .footer-connect__list a:hover,
+.editor-styles-wrapper .footer-connect__list a:focus-visible {
+    color: var(--neon-cyan);
+    text-shadow: 0 0 10px rgba(0, 229, 255, 0.45);
 }
 
-.editor-styles-wrapper .footer-contact a {
-    color: var(--text-secondary);
-    text-decoration: none;
-    font-weight: 600;
+.editor-styles-wrapper .social-links-menu {
+    gap: 18px;
 }
 
 .editor-styles-wrapper .site-info {

--- a/parts/footer-neon.html
+++ b/parts/footer-neon.html
@@ -1,107 +1,79 @@
 <!-- wp:group {"tagName":"footer","className":"site-footer","style":{"spacing":{"padding":{"top":"clamp(48px, 6vw, 84px)","bottom":"clamp(48px, 6vw, 84px)","left":"clamp(24px, 6vw, 64px)","right":"clamp(24px, 6vw, 64px)"}}},"layout":{"type":"constrained","contentSize":"1400px"}} -->
 <footer class="wp-block-group site-footer" id="colophon" style="padding-top:clamp(48px, 6vw, 84px);padding-right:clamp(24px, 6vw, 64px);padding-bottom:clamp(48px, 6vw, 84px);padding-left:clamp(24px, 6vw, 64px)">
-  
-  <!-- Headline Section -->
-  <!-- wp:group {"className":"footer-headline","style":{"spacing":{"margin":{"bottom":"clamp(48px, 6vw, 72px)"}}},"layout":{"type":"constrained","contentSize":"800px"}} -->
-  <div class="wp-block-group footer-headline" style="margin-bottom:clamp(48px, 6vw, 72px)">
-    
-    <!-- wp:paragraph {"align":"center","className":"footer-eyebrow","style":{"typography":{"fontSize":"0.9rem","textTransform":"uppercase","letterSpacing":"0.15em"},"color":{"text":"#00e5ff"},"spacing":{"margin":{"bottom":"16px"}}}} -->
-    <p class="has-text-align-center footer-eyebrow" style="color:#00e5ff;margin-bottom:16px;font-size:0.9rem;letter-spacing:0.15em;text-transform:uppercase">Stay luminous</p>
-    <!-- /wp:paragraph -->
-    
-    <!-- wp:heading {"textAlign":"center","level":2,"className":"footer-headline__title","style":{"typography":{"fontSize":"clamp(2rem, 5vw, 3.5rem)","lineHeight":"1.2"},"spacing":{"margin":{"bottom":"20px"}}}} -->
-    <h2 class="wp-block-heading has-text-align-center footer-headline__title" style="margin-bottom:20px;font-size:clamp(2rem, 5vw, 3.5rem);line-height:1.2">Ready to build your next luminous launch?</h2>
-    <!-- /wp:heading -->
-    
-    <!-- wp:paragraph {"align":"center","className":"footer-headline__description","style":{"typography":{"fontSize":"1.1rem"},"spacing":{"margin":{"top":"0"}}}} -->
-    <p class="has-text-align-center footer-headline__description" style="margin-top:0;font-size:1.1rem">From bold strategy to neon-soaked visuals, we craft digital experiences that glow across every screen. Let's make something unforgettable together.</p>
-    <!-- /wp:paragraph -->
-    
-  </div>
-  <!-- /wp:group -->
-  
+
   <!-- Main Footer Grid -->
   <!-- wp:columns {"className":"footer-core","style":{"spacing":{"blockGap":{"top":"clamp(32px, 4vw, 48px)","left":"clamp(32px, 4vw, 48px)"}}}} -->
   <div class="wp-block-columns footer-core">
-    
-    <!-- Branding Column -->
-    <!-- wp:column {"width":"40%","className":"footer-branding"} -->
-    <div class="wp-block-column footer-branding" style="flex-basis:40%">
-      
+
+    <!-- Company Column -->
+    <!-- wp:column {"className":"footer-column footer-company"} -->
+    <div class="wp-block-column footer-column footer-company">
+
       <!-- wp:site-logo {"width":64,"className":"footer-logo","style":{"spacing":{"margin":{"bottom":"16px"}}}} /-->
-      
-      <!-- wp:site-title {"level":2,"className":"footer-site-title","style":{"typography":{"fontSize":"2rem"}}} /-->
-      
-      <!-- wp:paragraph {"className":"footer-tagline","style":{"typography":{"fontSize":"1rem"},"spacing":{"margin":{"top":"12px"}}}} -->
-      <p class="footer-tagline" style="margin-top:12px;font-size:1rem">Digital experiences with a neon soul—crafted in Columbus and deployed worldwide.</p>
+
+      <!-- wp:paragraph {"className":"footer-tagline"} -->
+      <p class="footer-tagline">Crafting digital experiences with a neon soul.</p>
       <!-- /wp:paragraph -->
-      
+
     </div>
     <!-- /wp:column -->
-    
+
     <!-- Quick Links Column -->
-    <!-- wp:column {"width":"20%","className":"footer-links"} -->
-    <div class="wp-block-column footer-links" style="flex-basis:20%">
-      
-      <!-- wp:paragraph {"className":"footer-section-title","style":{"typography":{"fontSize":"0.85rem","fontWeight":"700","textTransform":"uppercase","letterSpacing":"0.12em"},"spacing":{"margin":{"bottom":"16px"}}}} -->
-      <p class="footer-section-title" style="margin-bottom:16px;font-size:0.85rem;font-weight:700;letter-spacing:0.12em;text-transform:uppercase">Quick Links</p>
+    <!-- wp:column {"className":"footer-column footer-links"} -->
+    <div class="wp-block-column footer-column footer-links">
+
+      <!-- wp:paragraph {"className":"footer-section-title","style":{"spacing":{"margin":{"bottom":"16px"}}}} -->
+      <p class="footer-section-title" style="margin-bottom:16px">Quick Links</p>
       <!-- /wp:paragraph -->
-      
+
       <!-- wp:navigation {"className":"footer-nav","overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"12px"}}} /-->
-      
+
     </div>
     <!-- /wp:column -->
-    
-    <!-- Social Column -->
-    <!-- wp:column {"width":"20%","className":"footer-social"} -->
-    <div class="wp-block-column footer-social" style="flex-basis:20%">
-      
-      <!-- wp:paragraph {"className":"footer-section-title","style":{"typography":{"fontSize":"0.85rem","fontWeight":"700","textTransform":"uppercase","letterSpacing":"0.12em"},"spacing":{"margin":{"bottom":"16px"}}}} -->
-      <p class="footer-section-title" style="margin-bottom:16px;font-size:0.85rem;font-weight:700;letter-spacing:0.12em;text-transform:uppercase">Follow</p>
+
+    <!-- Connect Column -->
+    <!-- wp:column {"className":"footer-column footer-connect"} -->
+    <div class="wp-block-column footer-column footer-connect">
+
+      <!-- wp:paragraph {"className":"footer-section-title","style":{"spacing":{"margin":{"bottom":"16px"}}}} -->
+      <p class="footer-section-title" style="margin-bottom:16px">Connect</p>
       <!-- /wp:paragraph -->
-      
-      <!-- wp:social-links {"className":"social-links-menu","style":{"spacing":{"blockGap":{"top":"18px","left":"18px"}}}} -->
-      <ul class="wp-block-social-links social-links-menu">
+
+      <!-- wp:list {"className":"footer-connect__list"} -->
+      <ul class="footer-connect__list">
+        <!-- wp:list-item -->
+        <li><a href="mailto:hello@mccullough.digital">hello@mccullough.digital</a></li>
+        <!-- /wp:list-item -->
+
+        <!-- wp:list-item -->
+        <li><a href="/contact/">Book a discovery call →</a></li>
+        <!-- /wp:list-item -->
+      </ul>
+      <!-- /wp:list -->
+
+      <!-- wp:social-links {"className":"social-links-menu","layout":{"type":"flex"},"style":{"spacing":{"blockGap":{"top":"18px","left":"18px"}}},"label":"Social media"} -->
+      <ul class="wp-block-social-links social-links-menu" aria-label="Social media">
         <!-- wp:social-link {"url":"https://www.facebook.com/mcculloughdigital","service":"facebook"} /-->
         <!-- wp:social-link {"url":"https://www.instagram.com/mcculloughdigital","service":"instagram"} /-->
         <!-- wp:social-link {"url":"https://www.linkedin.com/company/mccullough-digital/","service":"linkedin"} /-->
       </ul>
       <!-- /wp:social-links -->
-      
+
     </div>
     <!-- /wp:column -->
-    
-    <!-- Contact Column -->
-    <!-- wp:column {"width":"20%","className":"footer-contact"} -->
-    <div class="wp-block-column footer-contact" style="flex-basis:20%">
-      
-      <!-- wp:paragraph {"className":"footer-section-title","style":{"typography":{"fontSize":"0.85rem","fontWeight":"700","textTransform":"uppercase","letterSpacing":"0.12em"},"spacing":{"margin":{"bottom":"16px"}}}} -->
-      <p class="footer-section-title" style="margin-bottom:16px;font-size:0.85rem;font-weight:700;letter-spacing:0.12em;text-transform:uppercase">Say hello</p>
-      <!-- /wp:paragraph -->
-      
-      <!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"8px"}}}} -->
-      <p style="margin-bottom:8px"><a href="mailto:hello@mccullough.digital">hello@mccullough.digital</a></p>
-      <!-- /wp:paragraph -->
-      
-      <!-- wp:paragraph -->
-      <p><a href="/contact/">Book a discovery call →</a></p>
-      <!-- /wp:paragraph -->
-      
-    </div>
-    <!-- /wp:column -->
-    
+
   </div>
   <!-- /wp:columns -->
-  
+
   <!-- Separator -->
   <!-- wp:separator {"className":"footer-separator","style":{"spacing":{"margin":{"top":"clamp(40px, 5vw, 64px)","bottom":"clamp(32px, 4vw, 48px)"}}}} -->
   <hr class="wp-block-separator has-alpha-channel-opacity footer-separator" style="margin-top:clamp(40px, 5vw, 64px);margin-bottom:clamp(32px, 4vw, 48px)"/>
   <!-- /wp:separator -->
-  
+
   <!-- Copyright -->
   <!-- wp:paragraph {"align":"center","className":"site-info","style":{"typography":{"fontSize":"0.9rem"}}} -->
   <p class="has-text-align-center site-info" style="font-size:0.9rem">© 2025 McCullough Digital. Crafted with heart, strategy, and a dash of neon.</p>
   <!-- /wp:paragraph -->
-  
+
 </footer>
 <!-- /wp:group -->

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ This theme does not have any widget areas registered by default.
 == Changelog ==
 
 = 1.2.39 - Unreleased =
+* **Footer Layout Streamlining:** Rebuilt the neon footer around a compact three-column grid, removed the promotional headline, and balanced company, quick link, and connect content per Plan A.
 * **Admin Toolbar Offset:** Added a `--mcd-admin-bar-offset` variable with desktop/mobile fallbacks, updated blog and menu wrappers to include it in their header padding, and extended the header script to measure `#wpadminbar` so logged-in views clear the combined toolbar and masthead.
 * **Header Offset Fallback Raised:** Increased the root `--header-height` token to 100px across front-end, editor, and standalone bundles so pages clear the fixed masthead even when header scripts fail.
 * **Blog Hero Offset Correction:** Restored the blog archive header padding and simplified the hero's top spacing so the masthead no longer overlaps the hero while retaining the intended breathing room.

--- a/style.css
+++ b/style.css
@@ -640,37 +640,6 @@ body.home main.site-content {
     z-index: var(--z-index-default);
 }
 
-.footer-headline {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 12px;
-    text-align: center;
-}
-
-.footer-eyebrow {
-    margin: 0;
-    text-transform: uppercase;
-    letter-spacing: 0.32em;
-    font-size: 0.75rem;
-    color: rgba(230, 241, 255, 0.7);
-}
-
-.footer-headline__title {
-    margin: 0;
-    font-family: 'Caveat', cursive;
-    font-size: clamp(2.2rem, 6vw, 3.6rem);
-    color: var(--text-primary);
-    text-shadow: 0 0 14px rgba(0, 229, 255, 0.5), 0 0 26px rgba(255, 0, 224, 0.35);
-}
-
-.footer-headline__description {
-    margin: 0;
-    max-width: 640px;
-    font-size: clamp(1rem, 2.2vw, 1.25rem);
-    color: rgba(214, 231, 255, 0.85);
-}
-
 .wp-block-separator.footer-separator {
     margin: 0;
     border: none;
@@ -679,16 +648,15 @@ body.home main.site-content {
     opacity: 0.45;
 }
 
-.footer-nav a:focus-visible,
-.footer-contact a:focus-visible {
+.footer-core a:focus-visible {
     outline: 2px solid var(--neon-cyan);
     outline-offset: 4px;
 }
 
 .footer-core {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: clamp(24px, 5vw, 48px);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: clamp(24px, 4vw, 48px);
     align-items: start;
     margin-bottom: 0;
 }
@@ -698,7 +666,7 @@ body.home main.site-content {
     min-height: 0;
 }
 
-.footer-branding {
+.footer-column {
     display: flex;
     flex-direction: column;
     gap: 16px;
@@ -706,44 +674,12 @@ body.home main.site-content {
 }
 
 .footer-links {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    align-items: flex-start;
+    gap: 20px;
 }
 
-.footer-branding .wp-block-site-logo {
+.footer-company .wp-block-site-logo {
     display: flex;
     justify-content: flex-start;
-}
-
-.footer-branding .custom-logo-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transition: transform 0.3s ease;
-}
-
-.footer-branding .custom-logo {
-    height: auto;
-    width: auto;
-    max-height: var(--logo-size-footer);
-    margin-bottom: 0;
-    filter: drop-shadow(0 0 8px rgba(0, 229, 255, 0.6));
-    transition: filter 0.3s ease;
-}
-
-.footer-branding .custom-logo-link:hover .custom-logo,
-.footer-branding .custom-logo-link:focus-visible .custom-logo {
-    filter: drop-shadow(0 0 20px rgba(0, 229, 255, 0.8)) drop-shadow(0 0 10px rgba(255, 0, 224, 0.55));
-}
-
-.footer-branding .wp-block-site-title {
-    font-family: 'Caveat', cursive;
-    font-size: clamp(2.2rem, 6vw, 3.2rem);
-    color: var(--text-primary);
-    margin: 0;
-    text-shadow: 0 0 12px rgba(0, 229, 255, 0.4);
 }
 
 .footer-tagline {
@@ -802,11 +738,30 @@ body.home main.site-content {
     margin: 0 0 16px;
 }
 
-.footer-social {
+.footer-connect {
+    gap: 20px;
+}
+
+.footer-connect__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    align-items: flex-start;
+    gap: 8px;
+}
+
+.footer-connect__list a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 600;
+    transition: color 0.25s ease, text-shadow 0.25s ease;
+}
+
+.footer-connect__list a:hover,
+.footer-connect__list a:focus-visible {
+    color: var(--neon-cyan);
+    text-shadow: 0 0 10px rgba(0, 229, 255, 0.45);
 }
 
 .social-links-menu {
@@ -855,34 +810,6 @@ body.home main.site-content {
 .footer-logo a:hover .custom-logo,
 .footer-logo a:focus-visible .custom-logo {
     filter: drop-shadow(0 0 20px rgba(0, 229, 255, 0.8)) drop-shadow(0 0 10px rgba(255, 0, 224, 0.55));
-}
-
-.footer-site-title {
-    font-family: 'Caveat', cursive;
-    font-size: clamp(2.2rem, 6vw, 3.2rem);
-    color: var(--text-primary);
-    margin: 0;
-    text-shadow: 0 0 12px rgba(0, 229, 255, 0.4);
-}
-
-.footer-contact {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    align-items: flex-start;
-}
-
-.footer-contact a {
-    color: var(--text-secondary);
-    text-decoration: none;
-    font-weight: 600;
-    transition: color 0.25s ease, text-shadow 0.25s ease;
-}
-
-.footer-contact a:hover,
-.footer-contact a:focus-visible {
-    color: var(--neon-cyan);
-    text-shadow: 0 0 10px rgba(0, 229, 255, 0.45);
 }
 
 .site-info {
@@ -1255,19 +1182,12 @@ body.home main.site-content {
         gap: 40px;
     }
 
-    .footer-branding,
-    .footer-social,
-    .footer-contact {
+    .footer-column {
         align-items: center;
         width: 100%;
     }
 
-    .footer-links {
-        align-items: center;
-        width: 100%;
-    }
-
-    .footer-branding .wp-block-site-logo {
+    .footer-company .wp-block-site-logo {
         justify-content: center;
     }
 
@@ -1275,16 +1195,24 @@ body.home main.site-content {
         align-items: center;
         gap: 16px;
     }
-    
+
+    .footer-tagline {
+        max-width: 100%;
+        text-align: center;
+    }
+
+    .footer-connect__list {
+        align-items: center;
+    }
+
+    .footer-connect__list a {
+        text-align: center;
+    }
+
     /* Better spacing for mobile footer sections */
     .footer-section-title {
         margin-bottom: 20px;
         font-size: 0.9rem;
-    }
-    
-    .footer-tagline {
-        max-width: 100%;
-        text-align: center;
     }
     
     /* Social icons spacing */


### PR DESCRIPTION
## Summary
- remove the hero-style headline from the neon footer template part
- rebuild the footer markup around three balanced utility columns and update shared styles for front end and editor
- document the streamlined layout in the changelog and QA log

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3f4007d508324a98a7679a1326454