### PR TITLE
Restore neon footer starfield overlay

### DIFF
--- a/bug-report.md
+++ b/bug-report.md
@@ -11,6 +11,9 @@ This rolling QA log tracks production-impacting fixes and follow-up checks for t
 - Focus areas: fixed masthead offsets, blog archive loop experience, reusable neon CTA components.
 
 ## Recent Sweeps (November 2025)
+- **2025-11-19 — Footer starfield overlay restore**
+  - Result: Reintroduced the `stars` layer markup and inner `.footer-container` wrapper so the neon footer regains its animated background and centred layout.
+  - Follow-up: Spot-check the Site Editor to confirm the HTML block persists and verify `prefers-reduced-motion` continues to disable the twinkle.
 - **2025-11-18 — Footer Plan A streamlining**
   - Result: Removed the hero-style headline from the neon footer, rebuilt the layout into balanced company, quick links, and connect columns, and synced editor/front-end styles for the slimmer structure.
   - Follow-up: Re-test footer navigation hover/focus states after the next design polish pass and confirm the contact list adapts if a phone number is added.

--- a/parts/footer-neon.html
+++ b/parts/footer-neon.html
@@ -1,9 +1,19 @@
 <!-- wp:group {"tagName":"footer","className":"site-footer","style":{"spacing":{"padding":{"top":"clamp(48px, 6vw, 84px)","bottom":"clamp(48px, 6vw, 84px)","left":"clamp(24px, 6vw, 64px)","right":"clamp(24px, 6vw, 64px)"}}},"layout":{"type":"constrained","contentSize":"1400px"}} -->
 <footer class="wp-block-group site-footer" id="colophon" style="padding-top:clamp(48px, 6vw, 84px);padding-right:clamp(24px, 6vw, 64px);padding-bottom:clamp(48px, 6vw, 84px);padding-left:clamp(24px, 6vw, 64px)">
 
-  <!-- Main Footer Grid -->
-  <!-- wp:columns {"className":"footer-core","style":{"spacing":{"blockGap":{"top":"clamp(32px, 4vw, 48px)","left":"clamp(32px, 4vw, 48px)"}}}} -->
-  <div class="wp-block-columns footer-core">
+  <!-- Starfield Overlay -->
+  <!-- wp:html -->
+  <div class="stars" aria-hidden="true"></div>
+  <div class="stars2" aria-hidden="true"></div>
+  <div class="stars3" aria-hidden="true"></div>
+  <!-- /wp:html -->
+
+  <!-- wp:group {"tagName":"div","className":"footer-container"} -->
+  <div class="wp-block-group footer-container">
+
+    <!-- Main Footer Grid -->
+    <!-- wp:columns {"className":"footer-core","style":{"spacing":{"blockGap":{"top":"clamp(32px, 4vw, 48px)","left":"clamp(32px, 4vw, 48px)"}}}} -->
+    <div class="wp-block-columns footer-core">
 
     <!-- Company Column -->
     <!-- wp:column {"className":"footer-column footer-company"} -->
@@ -62,18 +72,21 @@
     </div>
     <!-- /wp:column -->
 
+    </div>
+    <!-- /wp:columns -->
+
+    <!-- Separator -->
+    <!-- wp:separator {"className":"footer-separator","style":{"spacing":{"margin":{"top":"clamp(40px, 5vw, 64px)","bottom":"clamp(32px, 4vw, 48px)"}}}} -->
+    <hr class="wp-block-separator has-alpha-channel-opacity footer-separator" style="margin-top:clamp(40px, 5vw, 64px);margin-bottom:clamp(32px, 4vw, 48px)"/>
+    <!-- /wp:separator -->
+
+    <!-- Copyright -->
+    <!-- wp:paragraph {"align":"center","className":"site-info","style":{"typography":{"fontSize":"0.9rem"}}} -->
+    <p class="has-text-align-center site-info" style="font-size:0.9rem">© 2025 McCullough Digital. Crafted with heart, strategy, and a dash of neon.</p>
+    <!-- /wp:paragraph -->
+
   </div>
-  <!-- /wp:columns -->
-
-  <!-- Separator -->
-  <!-- wp:separator {"className":"footer-separator","style":{"spacing":{"margin":{"top":"clamp(40px, 5vw, 64px)","bottom":"clamp(32px, 4vw, 48px)"}}}} -->
-  <hr class="wp-block-separator has-alpha-channel-opacity footer-separator" style="margin-top:clamp(40px, 5vw, 64px);margin-bottom:clamp(32px, 4vw, 48px)"/>
-  <!-- /wp:separator -->
-
-  <!-- Copyright -->
-  <!-- wp:paragraph {"align":"center","className":"site-info","style":{"typography":{"fontSize":"0.9rem"}}} -->
-  <p class="has-text-align-center site-info" style="font-size:0.9rem">© 2025 McCullough Digital. Crafted with heart, strategy, and a dash of neon.</p>
-  <!-- /wp:paragraph -->
+  <!-- /wp:group -->
 
 </footer>
 <!-- /wp:group -->

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,7 @@ This theme does not have any widget areas registered by default.
 
 = 1.2.39 - Unreleased =
 * **Footer Layout Streamlining:** Rebuilt the neon footer around a compact three-column grid, removed the promotional headline, and balanced company, quick link, and connect content per Plan A.
+* **Footer Starfield Restore:** Reintroduced the hidden starfield layers and wrapping container so the neon footer regains its animated background and centred layout.
 * **Admin Toolbar Offset:** Added a `--mcd-admin-bar-offset` variable with desktop/mobile fallbacks, updated blog and menu wrappers to include it in their header padding, and extended the header script to measure `#wpadminbar` so logged-in views clear the combined toolbar and masthead.
 * **Header Offset Fallback Raised:** Increased the root `--header-height` token to 100px across front-end, editor, and standalone bundles so pages clear the fixed masthead even when header scripts fail.
 * **Blog Hero Offset Correction:** Restored the blog archive header padding and simplified the hero's top spacing so the masthead no longer overlaps the hero while retaining the intended breathing room.


### PR DESCRIPTION
## Summary
- add the hidden `stars` layer markup back to the neon footer template part so the animated background renders again
- wrap the footer content in the `.footer-container` group to realign the grid with its centering styles
- document the restoration in the changelog and QA log

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3fcda4e088324bb020d3b3c362812