### PR TITLE
Fix neon button registration for child themes

### DIFF
--- a/bug-report.md
+++ b/bug-report.md
@@ -1,4 +1,4 @@
-# Bug Fix Report — Opened 2025-09-27 (Last updated 2025-11-14 — Neon button editor parity verified)
+# Bug Fix Report — Opened 2025-09-27 (Last updated 2025-11-21 — Neon button child-theme parity fix staged)
 
 This rolling QA log tracks production-impacting fixes and follow-up checks for the McCullough Digital theme. Use it to understand **when** a regression was addressed, what still needs verification, and where to find the detailed release notes.
 
@@ -11,6 +11,9 @@ This rolling QA log tracks production-impacting fixes and follow-up checks for t
 - Focus areas: fixed masthead offsets, blog archive loop experience, reusable neon CTA components.
 
 ## Recent Sweeps (November 2025)
+- **2025-11-21 — Neon button child-theme parity**
+  - Result: Block registration now scans both child and parent theme `blocks/` directories and enqueues button assets via `get_theme_file_*()` so the neon CTA renders with styling on front-end views when a child theme is active.
+  - Follow-up: Smoke-test on a production child theme after the next deploy to confirm the button outputs markup + CSS and that child overrides continue to win when present.
 - **2025-11-20 — Footer column spacing + separator removal**
   - Result: Let the neon footer grid keep the branding column snug, centred the navigation and contact columns, and removed the decorative separator so the logo/tagline stack no longer shows a faint horizontal line.
   - Follow-up: Reconfirm layout balance after adding or removing footer columns in the Site Editor and ensure custom separators elsewhere remain unaffected.

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ This theme does not have any widget areas registered by default.
 == Changelog ==
 
 = 1.2.39 - Unreleased =
+* **Neon Button Front-End Restore:** Register block metadata from both child and parent theme `blocks/` folders and load the button assets with `get_theme_file_*()` helpers so the neon CTA renders with styling on sites running a child theme.
 * **Footer Column Alignment:** Let the neon footer grid size the branding column to its content, centered the remaining columns, and removed the decorative separator so the tagline no longer shows a stray line.
 * **Footer Layout Streamlining:** Rebuilt the neon footer around a compact three-column grid, removed the promotional headline, and balanced company, quick link, and connect content per Plan A.
 * **Footer Starfield Restore:** Reintroduced the hidden starfield layers and wrapping container so the neon footer regains its animated background and centred layout.


### PR DESCRIPTION
## Summary
- load button, script, and optional debug assets via get_theme_file_path/uri so parent bundles are reachable when a child theme is active
- register dynamic blocks from both child and parent blocks directories while skipping duplicates
- document the child-theme neon button fix in the changelog and QA log

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4094fcfc88324981ed4351032ac76