### PR TITLE
Simplify hero CTA gradient sweep

### DIFF
--- a/blocks/button/style.css
+++ b/blocks/button/style.css
@@ -25,7 +25,7 @@
     margin-right: 0;
     align-self: auto;
     padding: clamp(0.85rem, 2.5vw, 1.1rem) clamp(2.5rem, 6vw, 3.25rem);
-    font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-family: "Nunito", sans-serif;
     font-weight: 700;
     font-size: clamp(1rem, 1.9vw, 1.15rem);
     letter-spacing: 0.04em;
@@ -37,8 +37,7 @@
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
     position: relative;
     overflow: hidden;
-    transition: color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease,
-        transform 0.35s ease, background-color 0.35s ease;
+    transition: all 0.35s ease;
     isolation: isolate;
     z-index: 0;
     cursor: pointer;
@@ -58,31 +57,17 @@
     margin-right: auto;
 }
 
-.wp-block-mccullough-digital-button .hero__cta-button::before,
-.wp-block-mccullough-digital-button .hero__cta-button::after {
+.wp-block-mccullough-digital-button .hero__cta-button::before {
     content: "";
     position: absolute;
     inset: 0;
     border-radius: inherit;
     pointer-events: none;
-    transition: transform 0.55s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.45s ease;
-}
-
-.wp-block-mccullough-digital-button .hero__cta-button::before {
+    transition: transform 0.55s cubic-bezier(0.77, 0, 0.175, 1);
     background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
     transform: translateX(-110%);
     opacity: 0.85;
     z-index: -1;
-}
-
-.wp-block-mccullough-digital-button .hero__cta-button::after {
-    inset: -35%;
-    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 55%),
-        radial-gradient(circle at 70% 30%, rgba(255, 0, 224, 0.3), transparent 60%);
-    opacity: 0;
-    transform: scale(0.9);
-    filter: blur(12px);
-    z-index: -2;
 }
 
 .wp-block-mccullough-digital-button .hero__cta-button:hover,
@@ -95,12 +80,6 @@
 .wp-block-mccullough-digital-button .hero__cta-button:hover::before,
 .wp-block-mccullough-digital-button .hero__cta-button:focus-visible::before {
     transform: translateX(0);
-}
-
-.wp-block-mccullough-digital-button .hero__cta-button:hover::after,
-.wp-block-mccullough-digital-button .hero__cta-button:focus-visible::after {
-    opacity: 1;
-    transform: scale(1.05);
 }
 
 .wp-block-mccullough-digital-button .hero__cta-button:focus-visible {

--- a/blocks/hero/style.css
+++ b/blocks/hero/style.css
@@ -176,7 +176,7 @@
     margin-right: 0;
     align-self: auto;
     padding: clamp(0.85rem, 2.5vw, 1.1rem) clamp(2.5rem, 6vw, 3.25rem);
-    font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-family: "Nunito", sans-serif;
     font-weight: 700;
     font-size: clamp(1rem, 1.9vw, 1.15rem);
     letter-spacing: 0.04em;
@@ -188,39 +188,24 @@
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
     position: relative;
     overflow: hidden;
-    transition: color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease,
-        transform 0.35s ease, background-color 0.35s ease;
+    transition: all 0.35s ease;
     isolation: isolate;
     z-index: 0;
     cursor: pointer;
     appearance: none;
 }
 
-.wp-block-mccullough-digital-hero .hero__cta-button::before,
-.wp-block-mccullough-digital-hero .hero__cta-button::after {
+.wp-block-mccullough-digital-hero .hero__cta-button::before {
     content: "";
     position: absolute;
     inset: 0;
     border-radius: inherit;
     pointer-events: none;
-    transition: transform 0.55s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.45s ease;
-}
-
-.wp-block-mccullough-digital-hero .hero__cta-button::before {
+    transition: transform 0.55s cubic-bezier(0.77, 0, 0.175, 1);
     background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
     transform: translateX(-110%);
     opacity: 0.85;
     z-index: -1;
-}
-
-.wp-block-mccullough-digital-hero .hero__cta-button::after {
-    inset: -35%;
-    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 55%),
-        radial-gradient(circle at 70% 30%, rgba(255, 0, 224, 0.3), transparent 60%);
-    opacity: 0;
-    transform: scale(0.9);
-    filter: blur(12px);
-    z-index: -2;
 }
 
 .wp-block-mccullough-digital-hero .hero__cta-button:hover,
@@ -233,12 +218,6 @@
 .wp-block-mccullough-digital-hero .hero__cta-button:hover::before,
 .wp-block-mccullough-digital-hero .hero__cta-button:focus-visible::before {
     transform: translateX(0);
-}
-
-.wp-block-mccullough-digital-hero .hero__cta-button:hover::after,
-.wp-block-mccullough-digital-hero .hero__cta-button:focus-visible::after {
-    opacity: 1;
-    transform: scale(1.05);
 }
 
 .wp-block-mccullough-digital-hero .hero__cta-button:focus-visible {

--- a/bug-report.md
+++ b/bug-report.md
@@ -1,4 +1,4 @@
-# Bug Fix Report — Opened 2025-09-27 (Last updated 2025-11-21 — Neon button child-theme parity fix staged)
+# Bug Fix Report — Opened 2025-09-27 (Last updated 2025-11-22 — Hero CTA gradient sweep synced)
 
 This rolling QA log tracks production-impacting fixes and follow-up checks for the McCullough Digital theme. Use it to understand **when** a regression was addressed, what still needs verification, and where to find the detailed release notes.
 
@@ -11,6 +11,9 @@ This rolling QA log tracks production-impacting fixes and follow-up checks for t
 - Focus areas: fixed masthead offsets, blog archive loop experience, reusable neon CTA components.
 
 ## Recent Sweeps (November 2025)
+- **2025-11-22 — Hero CTA gradient sweep sync**
+  - Result: Updated the hero block, reusable CTA button block, and editor styles to use the slimmer gradient slide pill without the extra glow layer so both contexts render the provided hover animation consistently.
+  - Follow-up: Re-test the hero block in a fresh template and confirm the Site Editor loads the revised CSS after the next build deploy.
 - **2025-11-21 — Neon button child-theme parity**
   - Result: Block registration now scans both child and parent theme `blocks/` directories and enqueues button assets via `get_theme_file_*()` so the neon CTA renders with styling on front-end views when a child theme is active.
   - Follow-up: Smoke-test on a production child theme after the next deploy to confirm the button outputs markup + CSS and that child overrides continue to win when present.

--- a/editor-style.css
+++ b/editor-style.css
@@ -246,7 +246,7 @@
     margin-right: 0;
     align-self: auto;
     padding: clamp(0.85rem, 2.5vw, 1.1rem) clamp(2.5rem, 6vw, 3.25rem);
-    font-family: "Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-family: "Nunito", sans-serif;
     font-weight: 700;
     font-size: clamp(1rem, 1.9vw, 1.15rem);
     letter-spacing: 0.04em;
@@ -258,39 +258,24 @@
     box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
     position: relative;
     overflow: hidden;
-    transition: color 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease,
-        transform 0.35s ease, background-color 0.35s ease;
+    transition: all 0.35s ease;
     isolation: isolate;
     z-index: 0;
     cursor: pointer;
     appearance: none;
 }
 
-.editor-styles-wrapper .hero__cta-button::before,
-.editor-styles-wrapper .hero__cta-button::after {
+.editor-styles-wrapper .hero__cta-button::before {
     content: "";
     position: absolute;
     inset: 0;
     border-radius: inherit;
     pointer-events: none;
-    transition: transform 0.55s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.45s ease;
-}
-
-.editor-styles-wrapper .hero__cta-button::before {
+    transition: transform 0.55s cubic-bezier(0.77, 0, 0.175, 1);
     background: linear-gradient(90deg, var(--neon-cyan), var(--neon-magenta));
     transform: translateX(-110%);
     opacity: 0.85;
     z-index: -1;
-}
-
-.editor-styles-wrapper .hero__cta-button::after {
-    inset: -35%;
-    background: radial-gradient(circle, rgba(0, 229, 255, 0.35), transparent 55%),
-        radial-gradient(circle at 70% 30%, rgba(255, 0, 224, 0.3), transparent 60%);
-    opacity: 0;
-    transform: scale(0.9);
-    filter: blur(12px);
-    z-index: -2;
 }
 
 .editor-styles-wrapper .hero__cta-button:hover,
@@ -303,12 +288,6 @@
 .editor-styles-wrapper .hero__cta-button:hover::before,
 .editor-styles-wrapper .hero__cta-button:focus-visible::before {
     transform: translateX(0);
-}
-
-.editor-styles-wrapper .hero__cta-button:hover::after,
-.editor-styles-wrapper .hero__cta-button:focus-visible::after {
-    opacity: 1;
-    transform: scale(1.05);
 }
 
 .editor-styles-wrapper .hero__cta-button:focus-visible {

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ This theme does not have any widget areas registered by default.
 == Changelog ==
 
 = 1.2.39 - Unreleased =
+* **Hero CTA Gradient Slide:** Replaced the neon CTA's dual-glow treatment with the slimmer gradient sweep pill and synced the hero and reusable button block styles so both render the new hover animation in the editor and front end.
 * **Neon Button Front-End Restore:** Register block metadata from both child and parent theme `blocks/` folders and load the button assets with `get_theme_file_*()` helpers so the neon CTA renders with styling on sites running a child theme.
 * **Footer Column Alignment:** Let the neon footer grid size the branding column to its content, centered the remaining columns, and removed the decorative separator so the tagline no longer shows a stray line.
 * **Footer Layout Streamlining:** Rebuilt the neon footer around a compact three-column grid, removed the promotional headline, and balanced company, quick link, and connect content per Plan A.


### PR DESCRIPTION
## Summary
- replace the hero and reusable CTA button styling with the new gradient slide treatment so the provided hover animation matches the design across front end and editor
- document the update in the changelog and QA log for the ongoing 1.2.39 release notes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e43d7900348324b0aa0d5c467c290f