### PR TITLE
Align CTA block fallback with hero CTA styles

### DIFF
--- a/blocks/cta/render.php
+++ b/blocks/cta/render.php
@@ -44,14 +44,14 @@ if ( ! $has_inner_block ) {
     if ( '' !== $button_text ) {
         if ( $has_link_url ) {
             ?>
-            <a href="<?php echo esc_url( $button_link ); ?>" class="cta-button">
-                <span class="btn-text"><?php echo esc_html( $button_text ); ?></span>
+            <a href="<?php echo esc_url( $button_link ); ?>" class="cta-button hero__cta-button">
+                <span class="hero__cta-button-label"><?php echo esc_html( $button_text ); ?></span>
             </a>
             <?php
         } else {
             ?>
-            <span class="cta-button is-static" aria-hidden="true">
-                <span class="btn-text"><?php echo esc_html( $button_text ); ?></span>
+            <span class="cta-button hero__cta-button is-static" aria-hidden="true">
+                <span class="hero__cta-button-label"><?php echo esc_html( $button_text ); ?></span>
             </span>
             <?php
         }

--- a/blocks/cta/style.css
+++ b/blocks/cta/style.css
@@ -42,7 +42,7 @@
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link,
-.wp-block-mccullough-digital-cta .cta-button {
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button) {
     position: relative;
     overflow: hidden;
     padding: 15px 42px;
@@ -55,7 +55,7 @@
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link::before,
-.wp-block-mccullough-digital-cta .cta-button::before {
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button)::before {
     content: '';
     position: absolute;
     inset: 0;
@@ -69,7 +69,7 @@
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link::after,
-.wp-block-mccullough-digital-cta .cta-button::after {
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button)::after {
     content: '';
     position: absolute;
     inset: -18px;
@@ -83,26 +83,26 @@
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link:hover,
-.wp-block-mccullough-digital-cta .cta-button:hover,
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button):hover,
 .wp-block-mccullough-digital-cta .wp-block-button__link:focus-visible,
-.wp-block-mccullough-digital-cta .cta-button:focus-visible {
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button):focus-visible {
     transform: translateY(-4px) scale(1.03);
     color: var(--background-dark);
     box-shadow: 0 18px 40px rgba(0, 229, 255, 0.35), 0 0 36px rgba(255, 0, 224, 0.3);
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link:hover::before,
-.wp-block-mccullough-digital-cta .cta-button:hover::before,
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button):hover::before,
 .wp-block-mccullough-digital-cta .wp-block-button__link:focus-visible::before,
-.wp-block-mccullough-digital-cta .cta-button:focus-visible::before {
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button):focus-visible::before {
     opacity: 1;
     transform: scaleX(1);
 }
 
 .wp-block-mccullough-digital-cta .wp-block-button__link:hover::after,
-.wp-block-mccullough-digital-cta .cta-button:hover::after,
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button):hover::after,
 .wp-block-mccullough-digital-cta .wp-block-button__link:focus-visible::after,
-.wp-block-mccullough-digital-cta .cta-button:focus-visible::after {
+.wp-block-mccullough-digital-cta .cta-button:not(.hero__cta-button):focus-visible::after {
     opacity: 0.95;
     transform: scale(1);
 }

--- a/bug-report.md
+++ b/bug-report.md
@@ -1,4 +1,4 @@
-# Bug Fix Report — Opened 2025-09-27 (Last updated 2025-11-22 — Hero CTA gradient sweep synced)
+# Bug Fix Report — Opened 2025-09-27 (Last updated 2025-11-23 — CTA block hero fallback)
 
 This rolling QA log tracks production-impacting fixes and follow-up checks for the McCullough Digital theme. Use it to understand **when** a regression was addressed, what still needs verification, and where to find the detailed release notes.
 
@@ -11,6 +11,9 @@ This rolling QA log tracks production-impacting fixes and follow-up checks for t
 - Focus areas: fixed masthead offsets, blog archive loop experience, reusable neon CTA components.
 
 ## Recent Sweeps (November 2025)
+- **2025-11-23 — CTA block hero fallback**
+  - Result: Fallback markup now renders the `.cta-button.hero__cta-button` anchor/span pair and CTA block gradients skip the hero class so default buttons inherit the neon sweep styling instead of reverting to the legacy pill.
+  - Follow-up: Re-test the CTA block in the Site Editor after rebuilding assets to confirm the hero sweep loads and legacy `.cta-button` variants keep their gradient.
 - **2025-11-22 — Hero CTA gradient sweep sync**
   - Result: Updated the hero block, reusable CTA button block, and editor styles to use the slimmer gradient slide pill without the extra glow layer so both contexts render the provided hover animation consistently.
   - Follow-up: Re-test the hero block in a fresh template and confirm the Site Editor loads the revised CSS after the next build deploy.

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,7 @@ This theme does not have any widget areas registered by default.
 = 1.2.39 - Unreleased =
 * **Hero CTA Gradient Slide:** Replaced the neon CTA's dual-glow treatment with the slimmer gradient sweep pill and synced the hero and reusable button block styles so both render the new hover animation in the editor and front end.
 * **Neon Button Front-End Restore:** Register block metadata from both child and parent theme `blocks/` folders and load the button assets with `get_theme_file_*()` helpers so the neon CTA renders with styling on sites running a child theme.
+* **CTA Block Hero Fallback:** Updated the CTA block's PHP fallback to render the hero CTA markup and scoped the legacy gradient selectors away from `.hero__cta-button` instances so the block inherits the neon sweep styling by default.
 * **Footer Column Alignment:** Let the neon footer grid size the branding column to its content, centered the remaining columns, and removed the decorative separator so the tagline no longer shows a stray line.
 * **Footer Layout Streamlining:** Rebuilt the neon footer around a compact three-column grid, removed the promotional headline, and balanced company, quick link, and connect content per Plan A.
 * **Footer Starfield Restore:** Reintroduced the hidden starfield layers and wrapping container so the neon footer regains its animated background and centred layout.


### PR DESCRIPTION
## Summary
- update the CTA block fallback markup to render the hero CTA button classes and label wrapper
- keep the CTA block gradient selectors from overriding `.hero__cta-button` variants so the neon sweep styling persists
- log the fallback change in the theme changelog and QA report

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e44a07e41083248c9fd0723cb9d07f